### PR TITLE
Kjt 20220308 comment out quarter fields from sql

### DIFF
--- a/src/tacos_source_database.sql/Load AZURE Tacos SQL Server Agent Job.sql
+++ b/src/tacos_source_database.sql/Load AZURE Tacos SQL Server Agent Job.sql
@@ -95,8 +95,8 @@ EXEC @ReturnCode = msdb.dbo.sp_add_jobstep @job_id=@jobId, @step_name=N'Make a l
 		  ,"2ND_LEARNING_ACTIVITY" AS "SecondLearningActivity"
 	      ,"3RD_LEARNING_ACTIVITY" AS "ThirdLearningActivity"
           ,"4TH_LEARNING_ACTIVITY" AS "FourthLearningActivity"
-		  ,CONVERT(nvarchar(4000), QUARTERS) AS "Quarters"
-		  ,QUARTERS_OFFERED AS "QuartersOffered"
+		  ,NULL AS "Quarters"
+		  ,NULL AS "QuartersOffered"
           ,EFFECTIVE_TERM AS "EffectiveTerm"
         ,STVTERM_DESC AS "Effective"
   	  FROM SIS..BANINST1.ZCVGVNT

--- a/src/tacos_source_database.sql/Load AZURE Tacos-Test SQL Server Agent Job.sql
+++ b/src/tacos_source_database.sql/Load AZURE Tacos-Test SQL Server Agent Job.sql
@@ -95,8 +95,8 @@ EXEC @ReturnCode = msdb.dbo.sp_add_jobstep @job_id=@jobId, @step_name=N'Make a l
 		  ,"2ND_LEARNING_ACTIVITY" AS "SecondLearningActivity"
 	      ,"3RD_LEARNING_ACTIVITY" AS "ThirdLearningActivity"
           ,"4TH_LEARNING_ACTIVITY" AS "FourthLearningActivity"
-		  ,CONVERT(nvarchar(4000), QUARTERS) AS "Quarters"
-		  ,QUARTERS_OFFERED AS "QuartersOffered"
+		  ,NULL AS "Quarters"
+		  ,NULL AS "QuartersOffered"
           ,EFFECTIVE_TERM AS "EffectiveTerm"
         ,STVTERM_DESC AS "Effective"
   	  FROM SIS..BANINST1.ZCVGVNT


### PR DESCRIPTION
Both the QUARTERS, and QUARTERS_OFFERED columns were removed from the SIS..BANINST1.ZCVGVNT table.  Attempting to select data from these 2 fields was causing the SSA job to fail.  I reviewed the code base and found that those 2 field only appear to be present in the SQL and the CourseDescription.cs mapping class.  Meaning they appear to play no role in the TACOS application.  Therefore, I revised the select for the insert statement to provide NULL values instead, keeping the rest of the code and SQL as-is.