### PR TITLE
Bootstrap to Tailwind/DaisyUI migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,5 +223,7 @@ _Pvt_Extensions
 !.vscode/settings.json
 !.vscode/extensions.json
 src/tacos.mvc/npm-shrinkwrap.json
+src/tacos.mvc/MigrationPlan.md
 
 *.jfm
+**/.DS_Store

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,13 @@ stages:
         arguments: '--configuration $(buildConfiguration)'
 
     - task: Npm@1
+      displayName: 'Run Client Lint'
+      inputs:
+        command: 'custom'
+        workingDir: './src/tacos.mvc'
+        customCommand: 'run lint'
+
+    - task: Npm@1
       displayName: 'Run Client Tests'
       inputs:
         command: 'custom'

--- a/src/tacos.mvc/ClientApp/app.tsx
+++ b/src/tacos.mvc/ClientApp/app.tsx
@@ -1,1 +1,2 @@
+import "./main.css";
 import "./css/site.scss";

--- a/src/tacos.mvc/ClientApp/components/CourseNumber.tsx
+++ b/src/tacos.mvc/ClientApp/components/CourseNumber.tsx
@@ -112,8 +112,14 @@ export default class CourseNumber extends React.Component<IProps, IState> {
 
         if (isValid && isNew) {
             return (
-                <button className="tacos-link-button tacos-link-button--icon" type="button" onClick={this.onCourseCreate}>
-                    <i className="far fa-fw fa-edit" />
+                <button
+                    aria-label="Edit new course details"
+                    className="tacos-link-button tacos-link-button--icon"
+                    onClick={this.onCourseCreate}
+                    title="Edit new course details"
+                    type="button"
+                >
+                    <i aria-hidden="true" className="far fa-fw fa-edit" />
                 </button>
             );
         }

--- a/src/tacos.mvc/ClientApp/components/CourseNumber.tsx
+++ b/src/tacos.mvc/ClientApp/components/CourseNumber.tsx
@@ -64,16 +64,17 @@ export default class CourseNumber extends React.Component<IProps, IState> {
 
         return (
             <div>
-                <div className="input-group">
+                <div className="tacos-input-group">
                     <input
+                        data-course-number-input="true"
                         type="text"
-                        className="form-control"
+                        className="tacos-input"
                         value={courseNumber}
                         onChange={this.onCourseNumberChange}
                     />
-                    <div className="input-group-append">
+                    <div className="tacos-input-group__addon">
                         <span
-                            className="input-group-text"
+                            className="tacos-input-group__status"
                             id="basic-addon2"
                             style={{ color: isValid ? "green" : "red" }}
                         >
@@ -82,16 +83,16 @@ export default class CourseNumber extends React.Component<IProps, IState> {
                     </div>
                 </div>
                 { notFound && (
-                    <small className="form-text pl-2">
-                        <span className="mr-3">Course Not Found!</span>
-                        <button className="btn-link p-0 border-0" style={{ cursor: "pointer" }} onClick={this.onCourseCreate}>
+                    <small className="tacos-form-help">
+                        <span className="tacos-form-help__message">Course Not Found!</span>
+                        <button className="tacos-link-button" type="button" onClick={this.onCourseCreate}>
                             Add new course?
                         </button>
                     </small>
                 )}
                 { isValid && (
-                    <small className="form-text text-muted pl-2">
-                        <span className="d-block text-truncate" title={courseName}>{ courseName }</span>
+                    <small className="tacos-form-help tacos-form-help--muted">
+                        <span className="tacos-truncate" title={courseName}>{ courseName }</span>
                     </small>
                 )}
             </div>
@@ -111,7 +112,7 @@ export default class CourseNumber extends React.Component<IProps, IState> {
 
         if (isValid && isNew) {
             return (
-                <button className="btn-link p-0 border-0" style={{ cursor: "pointer" }} onClick={this.onCourseCreate}>
+                <button className="tacos-link-button tacos-link-button--icon" type="button" onClick={this.onCourseCreate}>
                     <i className="far fa-fw fa-edit" />
                 </button>
             );

--- a/src/tacos.mvc/ClientApp/components/CourseType.tsx
+++ b/src/tacos.mvc/ClientApp/components/CourseType.tsx
@@ -9,17 +9,15 @@ interface IProps {
 export default class CourseType extends React.PureComponent<IProps, {}> {
     public render() {
         return (
-            <div className="input-group">
-                <select
-                    className="custom-select"
-                    value={this.props.courseType}
-                    onChange={this.onChange}
-                >
-                    {CourseTypeOptions.map(c => (
-                        <option key={c[0]} value={c[0]}>{c[1]}</option>
-                    ))}
-                </select>
-            </div>
+            <select
+                className="tacos-select"
+                value={this.props.courseType}
+                onChange={this.onChange}
+            >
+                {CourseTypeOptions.map(c => (
+                    <option key={c[0]} value={c[0]}>{c[1]}</option>
+                ))}
+            </select>
         );
     }
 

--- a/src/tacos.mvc/ClientApp/components/CreateCourseModal.tsx
+++ b/src/tacos.mvc/ClientApp/components/CreateCourseModal.tsx
@@ -47,18 +47,28 @@ export default class CreateCourseModal extends React.PureComponent<IProps, IStat
             <Modal isOpen={isOpen} onClose={onClose} centered={true}>
                 <ModalHeader>Create Course</ModalHeader>
                 <ModalBody>
-                    <div className="form-group">
-                        <label>Course Number</label>
-                        <input className="form-control" value={courseNumber} onChange={this.onChangeNumber} />
+                    <div className="tacos-form-field">
+                        <label className="tacos-form-label" htmlFor="create-course-number">Course Number</label>
+                        <input
+                            className="tacos-input"
+                            id="create-course-number"
+                            value={courseNumber}
+                            onChange={this.onChangeNumber}
+                        />
                     </div>
-                    <div className="form-group">
-                        <label>Course Name</label>
-                        <input className="form-control" value={courseName} onChange={this.onChangeName} />
+                    <div className="tacos-form-field">
+                        <label className="tacos-form-label" htmlFor="create-course-name">Course Name</label>
+                        <input
+                            className="tacos-input"
+                            id="create-course-name"
+                            value={courseName}
+                            onChange={this.onChangeName}
+                        />
                     </div>
                 </ModalBody>
-                <ModalFooter className="d-flex justify-content-between">
-                    <button type="button" className="btn btn-secondary" onClick={onClose}>Cancel</button>
-                    <button type="button" className="btn btn-primary" onClick={this.onSubmit}>Submit</button>
+                <ModalFooter className="tacos-modal-footer--split">
+                    <button type="button" className="tacos-btn tacos-btn--secondary" onClick={onClose}>Cancel</button>
+                    <button type="button" className="tacos-btn tacos-btn--primary" onClick={this.onSubmit}>Submit</button>
                 </ModalFooter>
             </Modal>
         );

--- a/src/tacos.mvc/ClientApp/components/Departments.tsx
+++ b/src/tacos.mvc/ClientApp/components/Departments.tsx
@@ -15,9 +15,9 @@ export default class Departments extends React.PureComponent<IProps, {}> {
 
     return (
       <div>
-        <label htmlFor="department">Your Department:</label>
+        <label className="tacos-form-label" htmlFor="department">Your Department:</label>
         <select
-          className="form-control"
+          className="tacos-select"
           id="department"
           value={departmentId}
           onChange={this.onChange}

--- a/src/tacos.mvc/ClientApp/components/ExceptionDetail.tsx
+++ b/src/tacos.mvc/ClientApp/components/ExceptionDetail.tsx
@@ -25,21 +25,11 @@ interface IState {
 export default class ExceptionDetail extends React.PureComponent<IProps, IState> {
     private isMountedFlag = false;
 
-    public static getDerivedStateFromProps(nextProps: IProps, prevState: IState) {
-        if (nextProps.exceptionReason !== prevState.exceptionReason) {
-            return {
-                exceptionReason: nextProps.exceptionReason,
-            };
-        }
-
-        return null;
-    }
-
     constructor(props: IProps) {
         super(props);
 
         this.state = {
-            exceptionReason: "",
+            exceptionReason: props.exceptionReason,
             revoked: false,
             isRevoking: false,
         };
@@ -47,6 +37,17 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
 
     public componentDidMount() {
         this.isMountedFlag = true;
+    }
+
+    public componentDidUpdate(prevProps: IProps) {
+        if (
+            prevProps.exceptionReason !== this.props.exceptionReason
+            && this.props.exceptionReason !== this.state.exceptionReason
+        ) {
+            this.setState({
+                exceptionReason: this.props.exceptionReason,
+            });
+        }
     }
 
     public componentWillUnmount() {

--- a/src/tacos.mvc/ClientApp/components/ExceptionDetail.tsx
+++ b/src/tacos.mvc/ClientApp/components/ExceptionDetail.tsx
@@ -63,7 +63,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
         }
 
         return (
-            <div className="exceptionRow mb-4">
+            <div className="exceptionRow">
                 <p>
                     <b>Proposed TA % per course offering</b>
                 </p>
@@ -89,7 +89,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
         }
 
         return (
-            <div className="exceptionRow mb-4 d-flex ">
+            <div className="exceptionRow exceptionRow--approved">
                 <p>
                     <b>
                         Your exception request for {this.props.exceptionTotal} TA% per course has
@@ -97,7 +97,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
                     </b>
                     <button
                         type="button"
-                        className="btn btn-link revokeLink ml-2 p-0 align-baseline"
+                        className="tacos-link-button revokeLink exceptionRow__revoke"
                         id="revoke-button"
                         onClick={this.revokedToggle}
                     >
@@ -122,7 +122,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
                 <div>
                     <Modal isOpen={true} onClose={this.revokedToggle}>
                         <ModalHeader>Please confirm</ModalHeader>
-                        <ModalBody className="d-flex justify-content-center taco-animation-container">
+                        <ModalBody className="taco-animation-container tacos-modal-body-centered">
                             Clicking the revoke approval button will reset this approved exception
                             to un-submitted status. If you have unsaved changes on this page, please
                             cancel and save them before proceeding.
@@ -131,7 +131,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
                             {this.renderRevokeButton()}
                             <button
                                 type="button"
-                                className="btn btn-secondary"
+                                className="tacos-btn tacos-btn--secondary"
                                 onClick={this.revokedToggle}
                             >
                                 Cancel
@@ -146,8 +146,8 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
     private renderRevokeButton = () => {
         if (this.state.isRevoking) {
             return (
-                <button type="button" className="btn btn-secondary" disabled={true}>
-                    <i className=" mr-3 fas fa-spinner fa-pulse fa-lg" />
+                <button type="button" className="tacos-btn tacos-btn--secondary" disabled={true}>
+                    <i className="fas fa-spinner fa-pulse fa-lg tacos-inline-icon-start" />
                     Revoking...
                 </button>
             );
@@ -155,7 +155,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
             return (
                 <button
                     type="button"
-                    className="btn btn-primary"
+                    className="tacos-btn tacos-btn--primary"
                     onClick={this.onRevokeClick}
                 >
                     Revoke Approval
@@ -167,7 +167,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
     private renderExceptionTotal = () => {
         return (
             <NumberInput
-                className="form-control"
+                className="tacos-input"
                 min={0}
                 step={0.25}
                 placeholder="Total FTE requested"
@@ -181,7 +181,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
     private renderExceptionAnnualCount = () => {
         return (
             <NumberInput
-                className="form-control"
+                className="tacos-input"
                 min={0}
                 step={0.25}
                 placeholder="Annual offerings requested"
@@ -204,7 +204,7 @@ export default class ExceptionDetail extends React.PureComponent<IProps, IState>
         const { exceptionReason } = this.state;
         return (
             <textarea
-                className="form-control"
+                className="tacos-textarea"
                 placeholder="Reason for exceptioning the course request"
                 rows={3}
                 value={exceptionReason}

--- a/src/tacos.mvc/ClientApp/components/Modal.test.tsx
+++ b/src/tacos.mvc/ClientApp/components/Modal.test.tsx
@@ -78,8 +78,9 @@ describe("Modal", () => {
 
         click(launchButton!);
 
-        const dialog = document.body.querySelector(".modal-dialog[role='dialog']") as HTMLDivElement | null;
-        const title = document.body.querySelector(".modal-title") as HTMLElement | null;
+        const dialog = document.body.querySelector("[data-tacos-modal-dialog='true'][role='dialog']") as HTMLDivElement | null;
+        const titleId = dialog?.getAttribute("aria-labelledby") || "";
+        const title = titleId ? document.getElementById(titleId) : null;
 
         expect(dialog).not.toBeNull();
         expect(title).not.toBeNull();
@@ -88,7 +89,7 @@ describe("Modal", () => {
 
         pressEscape();
 
-        expect(document.body.querySelector(".modal")).toBeNull();
+        expect(document.body.querySelector("[data-tacos-modal-root='true']")).toBeNull();
         expect(document.activeElement).toBe(launchButton);
     });
 

--- a/src/tacos.mvc/ClientApp/components/Modal.tsx
+++ b/src/tacos.mvc/ClientApp/components/Modal.tsx
@@ -75,7 +75,7 @@ function removeModalFromStack(entry: IModalStackEntry) {
     }
 }
 
-const Modal = ({ children, centered, isOpen, onClose }: IModalProps) => {
+const Modal = ({ children, centered: _centered, isOpen, onClose }: IModalProps) => {
     const dialogRef = React.useRef<HTMLDivElement>(null);
     const onCloseRef = React.useRef(onClose);
     const previousFocusedElementRef = React.useRef<HTMLElement | null>(null);
@@ -196,10 +196,7 @@ const Modal = ({ children, centered, isOpen, onClose }: IModalProps) => {
         return null;
     }
 
-    const modalClassName = joinClassNames(
-        "tacos-modal",
-        centered ? "tacos-modal--centered" : undefined,
-    );
+    const modalClassName = joinClassNames("tacos-modal");
 
     const dialogClassName = joinClassNames("tacos-modal__dialog");
 

--- a/src/tacos.mvc/ClientApp/components/Modal.tsx
+++ b/src/tacos.mvc/ClientApp/components/Modal.tsx
@@ -19,6 +19,8 @@ interface IModalStackEntry {
     token: symbol;
 }
 
+const BODY_OPEN_CLASS_NAME = "tacos-modal-open";
+
 let openModalCount = 0;
 let modalTitleCount = 0;
 const modalStack: IModalStackEntry[] = [];
@@ -119,7 +121,7 @@ const Modal = ({ children, centered, isOpen, onClose }: IModalProps) => {
         }
 
         openModalCount += 1;
-        document.body.classList.add("modal-open");
+        document.body.classList.add(BODY_OPEN_CLASS_NAME);
         previousFocusedElementRef.current = document.activeElement instanceof HTMLElement
             ? document.activeElement
             : null;
@@ -132,7 +134,7 @@ const Modal = ({ children, centered, isOpen, onClose }: IModalProps) => {
             openModalCount = Math.max(0, openModalCount - 1);
 
             if (openModalCount === 0) {
-                document.body.classList.remove("modal-open");
+                document.body.classList.remove(BODY_OPEN_CLASS_NAME);
             }
 
             removeModalFromStack(stackEntry);
@@ -194,34 +196,34 @@ const Modal = ({ children, centered, isOpen, onClose }: IModalProps) => {
         return null;
     }
 
-    const dialogClassName = joinClassNames(
-        "modal-dialog",
-        centered ? "modal-dialog-centered" : undefined,
+    const modalClassName = joinClassNames(
+        "tacos-modal",
+        centered ? "tacos-modal--centered" : undefined,
     );
+
+    const dialogClassName = joinClassNames("tacos-modal__dialog");
 
     return createPortal(
         <ModalTitleContext.Provider value={titleId}>
-            <>
+            <div
+                className={modalClassName}
+                data-tacos-modal-root="true"
+                onClick={handleBackdropClick}
+            >
                 <div
-                    className="modal fade show"
-                    style={{ display: "block" }}
-                    onClick={handleBackdropClick}
+                    aria-labelledby={titleId}
+                    aria-modal="true"
+                    className={dialogClassName}
+                    data-tacos-modal-dialog="true"
+                    onClick={stopPropagation}
+                    onKeyDown={handleDialogKeyDown}
+                    ref={dialogRef}
+                    role="dialog"
+                    tabIndex={-1}
                 >
-                    <div
-                        aria-labelledby={titleId}
-                        aria-modal="true"
-                        className={dialogClassName}
-                        onClick={stopPropagation}
-                        onKeyDown={handleDialogKeyDown}
-                        ref={dialogRef}
-                        role="dialog"
-                        tabIndex={-1}
-                    >
-                        <div className="modal-content">{children}</div>
-                    </div>
+                    <div className="tacos-modal__content">{children}</div>
                 </div>
-                <div className="modal-backdrop fade show" />
-            </>
+            </div>,
         </ModalTitleContext.Provider>,
         document.body,
     );
@@ -231,18 +233,20 @@ export const ModalHeader = ({ children, className }: IModalSectionProps) => {
     const titleId = React.useContext(ModalTitleContext);
 
     return (
-        <div className={joinClassNames("modal-header", className)}>
-            <h5 className="modal-title mb-0" id={titleId}>{children}</h5>
+        <div className={joinClassNames("tacos-modal__header", className)}>
+            <h5 className="tacos-modal__title" data-tacos-modal-title="true" id={titleId}>
+                {children}
+            </h5>
         </div>
     );
 };
 
 export const ModalBody = ({ children, className }: IModalSectionProps) => (
-    <div className={joinClassNames("modal-body", className)}>{children}</div>
+    <div className={joinClassNames("tacos-modal__body", className)}>{children}</div>
 );
 
 export const ModalFooter = ({ children, className }: IModalSectionProps) => (
-    <div className={joinClassNames("modal-footer", className)}>{children}</div>
+    <div className={joinClassNames("tacos-modal__footer", className)}>{children}</div>
 );
 
 export default Modal;

--- a/src/tacos.mvc/ClientApp/components/RequestType.tsx
+++ b/src/tacos.mvc/ClientApp/components/RequestType.tsx
@@ -9,16 +9,14 @@ interface IProps {
 export default class RequestType extends React.PureComponent<IProps, {}> {
     public render() {
         return (
-            <div className="input-group">
-                <select
-                    className="custom-select"
-                    value={this.props.requestType}
-                    onChange={this.onChange}
-                >
-                    <option value="TA">TA</option>
-                    <option value="READ">Reader</option>
-                </select>
-            </div>
+            <select
+                className="tacos-select"
+                value={this.props.requestType}
+                onChange={this.onChange}
+            >
+                <option value="TA">TA</option>
+                <option value="READ">Reader</option>
+            </select>
         );
     }
 

--- a/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
+++ b/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
@@ -313,6 +313,39 @@ describe("RequestsTable UI coverage", () => {
         expect(getVisibleRequestIds()).toEqual(["request-2", "request-3", "request-1"]);
     });
 
+    it("keeps unsaved rows at the bottom in insertion order when sorting", async () => {
+        await renderTable({
+            requests: [
+                createRequest(1, { course: createCourse({ number: "TAC 300", name: "Saved Three Hundred" }) }),
+                createRequest(2, { course: createCourse({ number: "TAC 020", name: "Saved Twenty" }) }),
+                createRequest(3, {
+                    course: createCourse({ number: "TAC 100", name: "Unsaved One Hundred" }),
+                    id: undefined,
+                }),
+                createRequest(4, {
+                    course: createCourse({ number: "TAC 050", name: "Unsaved Fifty" }),
+                    id: undefined,
+                }),
+            ]
+        });
+
+        await click(getSortButton("course"));
+        expect(getVisibleRequestIds()).toEqual([
+            "request-2",
+            "request-1",
+            "request-new-2",
+            "request-new-3",
+        ]);
+
+        await click(getSortButton("course"));
+        expect(getVisibleRequestIds()).toEqual([
+            "request-1",
+            "request-2",
+            "request-new-2",
+            "request-new-3",
+        ]);
+    });
+
     it("resizes adjacent columns from the divider handle and keeps the divider bound to the column on the left", async () => {
         await renderTable({
             requests: [

--- a/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
+++ b/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
@@ -466,7 +466,7 @@ describe("RequestsTable UI coverage", () => {
         expect(onEdit).toHaveBeenNthCalledWith(3, 1, { ...secondRequest, exception: true });
     });
 
-    it("forwards numeric edits from the expanded exception detail inputs and renders the reason field", async () => {
+    it("forwards numeric edits from the expanded exception detail inputs and preserves textarea typing until blur saves it", async () => {
         const onEdit = vi.fn();
 
         const request = createRequest(7, {
@@ -493,9 +493,11 @@ describe("RequestsTable UI coverage", () => {
 
         await setInputValue(totalInput!, "2.25");
         await setInputValue(annualCountInput!, "3");
+        await setInputValue(reasonInput!, "Updated justification");
         expect(onEdit).toHaveBeenNthCalledWith(1, 0, { ...request, exceptionTotal: 2.25 });
         expect(onEdit).toHaveBeenNthCalledWith(2, 0, { ...request, exceptionAnnualCount: 3 });
-        expect(reasonInput!.value).toBe("Existing justification");
+        expect(onEdit).toHaveBeenNthCalledWith(3, 0, { ...request, exceptionReason: "Updated justification" });
+        expect(reasonInput!.value).toBe("Updated justification");
     });
 
     it("renders new-course, validation, and every-other-year warning indicators", async () => {

--- a/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
+++ b/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
@@ -291,7 +291,9 @@ describe("RequestsTable UI coverage", () => {
         await click(getSortButton("course"));
         expect(getVisibleRequestIds()).toEqual(["request-2", "request-1"]);
 
-        const secondRowRemoveButton = getHost().querySelector("#request-2 .btn-danger") as HTMLButtonElement | null;
+        const secondRowRemoveButton = getHost().querySelector(
+            "#request-2 [data-remove-request-button='true']"
+        ) as HTMLButtonElement | null;
         expect(secondRowRemoveButton).not.toBeNull();
 
         await click(secondRowRemoveButton!);
@@ -572,7 +574,7 @@ describe("RequestsTable UI coverage", () => {
         expect(revokeLink).not.toBeNull();
 
         await click(revokeLink!);
-        const modal = document.body.querySelector(".modal") as HTMLElement | null;
+        const modal = document.body.querySelector("[data-tacos-modal-dialog='true']") as HTMLElement | null;
         expect(modal).not.toBeNull();
         expect(normalizeText(document.body.textContent)).toContain("Please confirm");
 
@@ -605,7 +607,7 @@ describe("RequestsTable UI coverage", () => {
         expect(revokeLink).not.toBeNull();
 
         await click(revokeLink!);
-        const modal = document.body.querySelector(".modal") as HTMLElement | null;
+        const modal = document.body.querySelector("[data-tacos-modal-dialog='true']") as HTMLElement | null;
         expect(modal).not.toBeNull();
 
         await click(getButtonByText("Revoke Approval", modal!));

--- a/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
+++ b/src/tacos.mvc/ClientApp/components/RequestsTable.test.tsx
@@ -526,9 +526,31 @@ describe("RequestsTable UI coverage", () => {
 
         await setInputValue(totalInput!, "2.25");
         await setInputValue(annualCountInput!, "3");
-        await setInputValue(reasonInput!, "Updated justification");
+
+        const textareaValueSetter = Object.getOwnPropertyDescriptor(
+            HTMLTextAreaElement.prototype,
+            "value",
+        )?.set;
+
+        expect(textareaValueSetter).toBeDefined();
+
+        act(() => {
+            reasonInput!.focus();
+            textareaValueSetter!.call(reasonInput!, "Updated justification");
+            reasonInput!.dispatchEvent(new Event("input", { bubbles: true }));
+            reasonInput!.dispatchEvent(new Event("change", { bubbles: true }));
+        });
+
         expect(onEdit).toHaveBeenNthCalledWith(1, 0, { ...request, exceptionTotal: 2.25 });
         expect(onEdit).toHaveBeenNthCalledWith(2, 0, { ...request, exceptionAnnualCount: 3 });
+        expect(onEdit).toHaveBeenCalledTimes(2);
+        expect(reasonInput!.value).toBe("Updated justification");
+
+        act(() => {
+            reasonInput!.blur();
+            reasonInput!.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+        });
+
         expect(onEdit).toHaveBeenNthCalledWith(3, 0, { ...request, exceptionReason: "Updated justification" });
         expect(reasonInput!.value).toBe("Updated justification");
     });

--- a/src/tacos.mvc/ClientApp/components/RequestsTable.tsx
+++ b/src/tacos.mvc/ClientApp/components/RequestsTable.tsx
@@ -384,7 +384,19 @@ const RequestsTable = (props: IProps) => {
     }, [startColumnResize]);
 
     const visibleColumnCount = table.getVisibleLeafColumns().length;
-    const rows = table.getRowModel().rows;
+    const rowModel = table.getRowModel();
+    const rows = React.useMemo(() => {
+        const persistedRows = rowModel.rows.filter((row) => row.original.request.id);
+        const unsavedRows = rowModel.rows
+            .filter((row) => !row.original.request.id)
+            .sort((leftRow, rightRow) => leftRow.original.originalIndex - rightRow.original.originalIndex);
+
+        if (unsavedRows.length === 0) {
+            return rowModel.rows;
+        }
+
+        return [...persistedRows, ...unsavedRows];
+    }, [rowModel.rows]);
 
     return (
         <div className={className}>

--- a/src/tacos.mvc/ClientApp/components/RequestsTable.tsx
+++ b/src/tacos.mvc/ClientApp/components/RequestsTable.tsx
@@ -121,9 +121,9 @@ const RequestsTable = (props: IProps) => {
             enableSorting: false,
             header: () => null,
             meta: {
-                className: "text-center align-middle",
+                className: "requests-cell--center requests-cell--middle",
                 filterVariant: "icon",
-                headerClassName: "text-center",
+                headerClassName: "requests-header-cell--center",
                 width: 45,
             } satisfies IColumnMeta,
         },
@@ -196,7 +196,7 @@ const RequestsTable = (props: IProps) => {
             header: "TA % per course offering",
             id: "calculatedTotal",
             meta: {
-                className: "text-center",
+                className: "requests-cell--center",
             } satisfies IColumnMeta,
         },
         {
@@ -205,7 +205,7 @@ const RequestsTable = (props: IProps) => {
             header: "Annualized TA FTE",
             id: "annualizedTotal",
             meta: {
-                className: "text-center",
+                className: "requests-cell--center",
             } satisfies IColumnMeta,
         },
         {
@@ -222,9 +222,9 @@ const RequestsTable = (props: IProps) => {
             header: "Exception ?",
             id: "exception",
             meta: {
-                className: "text-center align-middle",
+                className: "requests-cell--center requests-cell--middle",
                 filterVariant: "exception",
-                headerClassName: "text-center",
+                headerClassName: "requests-header-cell--center",
                 width: 150,
             } satisfies IColumnMeta,
         },
@@ -235,9 +235,9 @@ const RequestsTable = (props: IProps) => {
             enableSorting: false,
             header: "Remove",
             meta: {
-                className: "text-center align-middle",
+                className: "requests-cell--center requests-cell--middle",
                 filterVariant: "none",
-                headerClassName: "text-center",
+                headerClassName: "requests-header-cell--center",
                 width: 100,
             } satisfies IColumnMeta,
         },
@@ -248,9 +248,9 @@ const RequestsTable = (props: IProps) => {
             enableSorting: false,
             header: () => null,
             meta: {
-                className: "text-center align-middle",
+                className: "requests-cell--center requests-cell--middle",
                 filterVariant: "none",
-                headerClassName: "text-center",
+                headerClassName: "requests-header-cell--center",
                 width: 45,
             } satisfies IColumnMeta,
         },
@@ -388,8 +388,8 @@ const RequestsTable = (props: IProps) => {
 
     return (
         <div className={className}>
-            <div className="table-responsive">
-                <table className="table requests">
+            <div className="requests-table-scroll">
+                <table className="requests">
                     <colgroup>
                         {table.getVisibleLeafColumns().map((column) => (
                             <col
@@ -437,12 +437,10 @@ const RequestsTable = (props: IProps) => {
                                         >
                                             <div
                                                 className={buildClassName(
-                                                    "requests-header-cell-content",
-                                                    "d-flex align-items-center",
-                                                    canSort ? "justify-content-between" : undefined
+                                                    "requests-header-cell-content"
                                                 )}
                                             >
-                                                <div className="d-flex align-items-center">
+                                                <div className="requests-header-cell-label">
                                                     {header.isPlaceholder
                                                         ? null
                                                         : flexRender(header.column.columnDef.header, header.getContext())}
@@ -454,7 +452,7 @@ const RequestsTable = (props: IProps) => {
                                                             header.column.columnDef.header,
                                                             nextSortOrder,
                                                         )}
-                                                        className="btn btn-link btn-sm p-0 ml-2 requests-sort-button"
+                                                        className="requests-sort-button"
                                                         data-column-sort-button={header.column.id}
                                                         onClick={header.column.getToggleSortingHandler()}
                                                         type="button"
@@ -500,7 +498,7 @@ const RequestsTable = (props: IProps) => {
                     <tbody>
                         {rows.length === 0 && (
                             <tr>
-                                <td className="requests-empty-state text-center text-muted" colSpan={visibleColumnCount}>
+                                <td className="requests-empty-state requests-empty-state--muted" colSpan={visibleColumnCount}>
                                     No requests found.
                                 </td>
                             </tr>
@@ -540,7 +538,7 @@ const RequestsTable = (props: IProps) => {
                                     </tr>
                                     {request.exception && (
                                         <tr className="requests-detail-row">
-                                            <td className="p-0" colSpan={visibleColumnCount}>
+                                            <td className="requests-detail-cell" colSpan={visibleColumnCount}>
                                                 <ExceptionDetail
                                                     requestId={request.id || -1}
                                                     onExceptionAnnualCountChange={(exceptionAnnualCount) =>
@@ -593,16 +591,16 @@ const RequestsTable = (props: IProps) => {
         switch (meta.filterVariant) {
             case "icon":
                 return (
-                    <div className="text-center requests-filter-icon">
+                    <div className="requests-filter-icon">
                         <i aria-hidden="true" className="fas fa-filter" />
                     </div>
                 );
             case "course":
                 return (
-                    <div style={{ position: "relative" }}>
+                    <div className="requests-filter-control requests-search-filter">
                         <input
                             aria-label={getFilterLabel(column.id)}
-                            className="form-control"
+                            className="tacos-input requests-filter-input"
                             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                                 column.setFilterValue(e.target.value.toUpperCase())
                             }
@@ -611,22 +609,16 @@ const RequestsTable = (props: IProps) => {
                         />
                         <i
                             aria-hidden="true"
-                            className="fas fa-search"
-                            style={{
-                                position: "absolute",
-                                right: "10px",
-                                top: "2px",
-                                transform: "translateY(50%)",
-                            }}
+                            className="fas fa-search requests-search-filter__icon"
                         />
                     </div>
                 );
             case "courseType":
                 return (
-                    <div className="input-group">
+                    <div className="requests-filter-control">
                         <select
                             aria-label={getFilterLabel(column.id)}
-                            className="custom-select"
+                            className="tacos-select requests-filter-select"
                             onChange={(e: React.ChangeEvent<HTMLSelectElement>) => column.setFilterValue(e.target.value)}
                             value={currentValue}
                         >
@@ -641,10 +633,10 @@ const RequestsTable = (props: IProps) => {
                 );
             case "requestType":
                 return (
-                    <div className="input-group">
+                    <div className="requests-filter-control">
                         <select
                             aria-label={getFilterLabel(column.id)}
-                            className="custom-select"
+                            className="tacos-select requests-filter-select"
                             onChange={(e: React.ChangeEvent<HTMLSelectElement>) => column.setFilterValue(e.target.value)}
                             value={currentValue}
                         >
@@ -656,10 +648,10 @@ const RequestsTable = (props: IProps) => {
                 );
             case "exception":
                 return (
-                    <div className="input-group">
+                    <div className="requests-filter-control">
                         <select
                             aria-label={getFilterLabel(column.id)}
-                            className="custom-select"
+                            className="tacos-select requests-filter-select"
                             onChange={(e: React.ChangeEvent<HTMLSelectElement>) => column.setFilterValue(e.target.value)}
                             value={currentValue}
                         >
@@ -828,7 +820,7 @@ function renderIconTrigger(id: string, label: string, iconClassName: string) {
     return (
         <button
             aria-label={label}
-            className="btn p-0 border-0 bg-transparent align-baseline requests-icon-button"
+            className="requests-icon-button"
             id={id}
             type="button"
         >
@@ -898,8 +890,8 @@ function renderCourseType(
 
 function renderCourseTypeHeader() {
     return (
-        <div>
-            <span className="mr-3">Course Type</span>
+        <div className="requests-header-inline">
+            <span className="requests-header-label">Course Type</span>
             <a href="/CAES-TA-Guidelines 2018-23.pdf" rel="noopener noreferrer" target="_blank">
                 Criteria Info <i className="fas fa-external-link-alt" />
             </a>
@@ -928,8 +920,8 @@ function renderRequestType(
 
 function renderRequestTypeHeader() {
     return (
-        <div>
-            <span className="mr-2">Request Type</span>
+        <div className="requests-header-inline">
+            <span className="requests-header-label">Request Type</span>
             {renderIconTrigger(
                 "requestTypeHeader",
                 "Request type help",
@@ -968,7 +960,8 @@ function renderRemoveButton(row: IRequestTableRow, onRemove: (i: number) => void
     return (
         <button
             aria-label="Remove request"
-            className="btn btn-danger"
+            className="tacos-btn tacos-btn--danger tacos-btn--icon-only"
+            data-remove-request-button="true"
             type="button"
             onClick={() => onRemove(row.originalIndex)}
         >
@@ -990,7 +983,7 @@ function renderAnnualizedFTE(row: IRequestTableRow) {
                     {renderIconTrigger(
                         `request-${originalIndex}-otheryear-warning`,
                         "Every-other-year course warning",
-                        "fas fa-exclamation-triangle text-warning",
+                        "fas fa-exclamation-triangle tacos-text-warning",
                     )}
                     <UncontrolledTooltip
                         className=""
@@ -1016,7 +1009,7 @@ function renderWarnings(row: IRequestTableRow) {
                 {renderIconTrigger(
                     `request-${originalIndex}-error`,
                     "Request validation warning",
-                    "fas fa-exclamation-triangle text-danger",
+                    "fas fa-exclamation-triangle tacos-text-danger",
                 )}
                 <UncontrolledTooltip
                     className=""

--- a/src/tacos.mvc/ClientApp/components/Summary.tsx
+++ b/src/tacos.mvc/ClientApp/components/Summary.tsx
@@ -23,7 +23,6 @@ export default class Summary extends React.PureComponent<IProps, {}> {
         return (
             <button
                 className="tacos-btn tacos-btn--primary"
-                id="submit-button"
                 disabled={!this.props.canSave || this.props.isProcessing}
                 onClick={this.props.onSave}
                 type="button"
@@ -38,7 +37,6 @@ export default class Summary extends React.PureComponent<IProps, {}> {
         return (
             <button
                 className="tacos-btn tacos-btn--primary"
-                id="submit-button"
                 disabled={!this.props.canSubmit || this.props.isProcessing}
                 onClick={this.props.onSubmit}
                 type="button"

--- a/src/tacos.mvc/ClientApp/components/Summary.tsx
+++ b/src/tacos.mvc/ClientApp/components/Summary.tsx
@@ -22,13 +22,14 @@ export default class Summary extends React.PureComponent<IProps, {}> {
     public saveButtonRender = () => {
         return (
             <button
-                className="btn btn-primary"
+                className="tacos-btn tacos-btn--primary"
                 id="submit-button"
                 disabled={!this.props.canSave || this.props.isProcessing}
                 onClick={this.props.onSave}
+                type="button"
             >
                 Save Changes
-                <i className="far fa-save ml-2" />
+                <i className="far fa-save tacos-btn__icon" />
             </button>
         );
     };
@@ -36,31 +37,33 @@ export default class Summary extends React.PureComponent<IProps, {}> {
     public submitButtonRender = () => {
         return (
             <button
-                className="btn btn-primary"
+                className="tacos-btn tacos-btn--primary"
                 id="submit-button"
                 disabled={!this.props.canSubmit || this.props.isProcessing}
                 onClick={this.props.onSubmit}
+                type="button"
             >
                 Submit for Approval
-                <i className="far fa-thumbs-up ml-2" />
+                <i className="far fa-thumbs-up tacos-btn__icon" />
             </button>
         );
     };
 
     public render() {
         return (
-            <div className="navbar navbar-default navbar-expand-xs fixed-bottom" role="navigation">
+            <div className="navbar navbar-default tacos-summary-bar" role="navigation">
                 <div className="navbar-banner">
-                    <div className="container-fluid d-flex justify-content-between">
-                        <a className="navbar-brand navbar-brand mr-auto" href="#">
+                    <div className="tacos-summary-bar__content">
+                        <a className="navbar-brand tacos-summary-bar__title" href="#">
                             Request Total:{" "}
                             {this.props.total > 0 ? this.props.total.toFixed(3) : "---"}
                         </a>
-                        <div>
+                        <div className="tacos-summary-bar__actions">
                             <button
                                 disabled={this.props.isProcessing}
-                                className="btn btn-danger"
+                                className="tacos-btn tacos-btn--danger"
                                 onClick={this.props.onReset}
+                                type="button"
                             >
                                 Reset
                             </button>

--- a/src/tacos.mvc/ClientApp/components/Summary.tsx
+++ b/src/tacos.mvc/ClientApp/components/Summary.tsx
@@ -51,13 +51,13 @@ export default class Summary extends React.PureComponent<IProps, {}> {
 
     public render() {
         return (
-            <div className="navbar navbar-default tacos-summary-bar" role="navigation">
-                <div className="navbar-banner">
+            <div className="tacos-summary-bar" role="navigation">
+                <div className="tacos-summary-bar__banner">
                     <div className="tacos-summary-bar__content">
-                        <a className="navbar-brand tacos-summary-bar__title" href="#">
+                        <div className="tacos-summary-bar__title">
                             Request Total:{" "}
                             {this.props.total > 0 ? this.props.total.toFixed(3) : "---"}
-                        </a>
+                        </div>
                         <div className="tacos-summary-bar__actions">
                             <button
                                 disabled={this.props.isProcessing}

--- a/src/tacos.mvc/ClientApp/components/UncontrolledTooltip.tsx
+++ b/src/tacos.mvc/ClientApp/components/UncontrolledTooltip.tsx
@@ -211,31 +211,32 @@ const UncontrolledTooltip = ({
     }
 
     const tooltipClassName = [
-        "tooltip",
-        `bs-tooltip-${placement}`,
-        isOpen ? "show" : undefined,
+        "tacos-tooltip",
+        isOpen && isPositioned ? "tacos-tooltip--visible" : undefined,
         className,
     ].filter(Boolean).join(" ");
 
     const style: React.CSSProperties = {
         left,
+        opacity: isOpen && isPositioned ? 1 : 0,
         pointerEvents: "none",
         position: "fixed",
         top,
         visibility: isOpen && isPositioned ? "visible" : "hidden",
+        zIndex: 1080,
     };
 
     return createPortal(
         <div
             aria-hidden={!isOpen}
             className={tooltipClassName}
+            data-placement={placement}
             id={tooltipId}
             ref={tooltipRef}
             role="tooltip"
             style={style}
         >
-            <div className="arrow" />
-            <div className="tooltip-inner">{children}</div>
+            <div className="tacos-tooltip__content">{children}</div>
         </div>,
         document.body,
     );

--- a/src/tacos.mvc/ClientApp/containers/SubmissionContainer.test.tsx
+++ b/src/tacos.mvc/ClientApp/containers/SubmissionContainer.test.tsx
@@ -254,7 +254,7 @@ describe("SubmissionContainer formula UI coverage", () => {
             ]);
 
             const courseInput = getHost().querySelector(
-                "tbody tr[data-request-row='true'] input.form-control"
+                "tbody tr[data-request-row='true'] input[data-course-number-input='true']"
             ) as HTMLInputElement | null;
             const valueSetter = Object.getOwnPropertyDescriptor(
                 HTMLInputElement.prototype,
@@ -279,7 +279,7 @@ describe("SubmissionContainer formula UI coverage", () => {
             });
 
             const updatedInput = getHost().querySelector(
-                "tbody tr[data-request-row='true'] input.form-control"
+                "tbody tr[data-request-row='true'] input[data-course-number-input='true']"
             ) as HTMLInputElement | null;
 
             expect(updatedInput).toBeDefined();
@@ -324,7 +324,9 @@ describe("SubmissionContainer formula UI coverage", () => {
 
         expect(requestRows).toHaveLength(3);
 
-        const firstRowInput = requestRows[0].querySelector("input.form-control") as HTMLInputElement | null;
+        const firstRowInput = requestRows[0].querySelector(
+            "input[data-course-number-input='true']"
+        ) as HTMLInputElement | null;
         const secondRowText = normalizeText(requestRows[1].textContent);
         const thirdRowText = normalizeText(requestRows[2].textContent);
 

--- a/src/tacos.mvc/ClientApp/containers/SubmissionContainer.test.tsx
+++ b/src/tacos.mvc/ClientApp/containers/SubmissionContainer.test.tsx
@@ -292,7 +292,7 @@ describe("SubmissionContainer formula UI coverage", () => {
         }
     });
 
-    it("inserts a newly created empty request at the top of the table", async () => {
+    it("inserts a newly created empty request at the bottom of the table", async () => {
         await renderSubmission([
             createRequest("STD", {
                 name: "ECS 120",
@@ -324,16 +324,16 @@ describe("SubmissionContainer formula UI coverage", () => {
 
         expect(requestRows).toHaveLength(3);
 
-        const firstRowInput = requestRows[0].querySelector(
+        const firstRowText = normalizeText(requestRows[0].textContent);
+        const secondRowText = normalizeText(requestRows[1].textContent);
+        const thirdRowInput = requestRows[2].querySelector(
             "input[data-course-number-input='true']"
         ) as HTMLInputElement | null;
-        const secondRowText = normalizeText(requestRows[1].textContent);
-        const thirdRowText = normalizeText(requestRows[2].textContent);
 
-        expect(firstRowInput).not.toBeNull();
-        expect(firstRowInput!.value).toBe("");
-        expect(secondRowText).toContain("120");
-        expect(thirdRowText).toContain("140A");
+        expect(firstRowText).toContain("120");
+        expect(secondRowText).toContain("140A");
+        expect(thirdRowInput).not.toBeNull();
+        expect(thirdRowInput!.value).toBe("");
     });
 
     it("uses exception values in the rendered annualized totals once they are entered", async () => {

--- a/src/tacos.mvc/ClientApp/containers/SubmissionContainer.tsx
+++ b/src/tacos.mvc/ClientApp/containers/SubmissionContainer.tsx
@@ -68,11 +68,13 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
         }
 
         if (jsAction === "create") {
-            // check if first request is already empty
-            const firstRequest = requests[0];
-            if (!firstRequest || !firstRequest.course || !firstRequest.course.number) {
+            const lastRequestIndex = requests.length - 1;
+            const lastRequest = requests[lastRequestIndex];
+
+            // check if last request is already empty
+            if (lastRequest && (!lastRequest.course || !lastRequest.course.number)) {
                 // focus request
-                this.focusRequest(0);
+                this.focusRequest(lastRequestIndex);
                 return;
             }
 
@@ -494,6 +496,7 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
 
     private onAddRequest = () => {
         const newRequests: IRequest[] = [
+            ...this.state.requests,
             {
                 course: undefined,
                 courseName: "",
@@ -510,12 +513,12 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
                 hasApprovedException: false,
                 isValid: true,
             },
-            ...this.state.requests,
         ];
+        const newRequestIndex = newRequests.length - 1;
 
         this.setState({ requests: newRequests }, () => {
             // update isFocused to trigger ui flash
-            this.focusRequest(0);
+            this.focusRequest(newRequestIndex);
         });
     };
 

--- a/src/tacos.mvc/ClientApp/containers/SubmissionContainer.tsx
+++ b/src/tacos.mvc/ClientApp/containers/SubmissionContainer.tsx
@@ -115,21 +115,20 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
         const canSubmit = isValid;
 
         return (
-            <div className="pb-4">
-                <div className="row mb-4">
-                    <div className="col d-flex justify-content-end">
-                        <button
-                            className="btn btn-primary"
-                            id="submit-button"
-                            onClick={this.onAddRequest}
-                        >
-                            Create New Request
-                            <i className="fas fa-plus-circle ml-2" />
-                        </button>
-                    </div>
+            <div className="tacos-page-with-summary">
+                <div className="tacos-action-row tacos-action-row--end">
+                    <button
+                        className="tacos-btn tacos-btn--primary"
+                        id="submit-button"
+                        onClick={this.onAddRequest}
+                        type="button"
+                    >
+                        Create New Request
+                        <i className="fas fa-plus-circle tacos-btn__icon" />
+                    </button>
                 </div>
                 <RequestsTable
-                    className="mb-4"
+                    className="tacos-section-gap"
                     requests={requests}
                     onEdit={this.requestUpdated}
                     onRemove={this.removeRequest}
@@ -142,17 +141,16 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
                     course={createCourseModel}
                     onCourseCreate={this.onCourseCreate}
                 />
-                <div className="row mb-4">
-                    <div className="col d-flex">
-                        <button
-                            className="btn btn-primary"
-                            id="submit-button"
-                            onClick={this.onAddRequest}
-                        >
-                            Create New Request
-                            <i className="fas fa-plus-circle ml-2" />
-                        </button>
-                    </div>
+                <div className="tacos-action-row">
+                    <button
+                        className="tacos-btn tacos-btn--primary"
+                        id="submit-button"
+                        onClick={this.onAddRequest}
+                        type="button"
+                    >
+                        Create New Request
+                        <i className="fas fa-plus-circle tacos-btn__icon" />
+                    </button>
                 </div>
                 <Summary
                     canSave={canSave}
@@ -178,10 +176,10 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
                 <div>
                     <Modal isOpen={true} centered={true}>
                         <ModalHeader>
-                            <i className=" mr-3 fas fa-spinner fa-pulse fa-lg" />
+                            <i className="fas fa-spinner fa-pulse fa-lg tacos-inline-icon-start" />
                             Saving...
                         </ModalHeader>
-                        <ModalBody className="d-flex justify-content-center taco-animation-container">
+                        <ModalBody className="taco-animation-container tacos-modal-body-centered">
                             <img className="w-75" src="tacoAnimation.gif" alt="taco animation gif"/>
                         </ModalBody>
                     </Modal>
@@ -196,10 +194,10 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
                 <div>
                     <Modal isOpen={true} centered={true}>
                         <ModalHeader>
-                            <i className=" mr-3 fas fa-spinner fa-pulse fa-lg" />
+                            <i className="fas fa-spinner fa-pulse fa-lg tacos-inline-icon-start" />
                             Submitting...
                         </ModalHeader>
-                        <ModalBody className="d-flex justify-content-center taco-animation-container">
+                        <ModalBody className="taco-animation-container tacos-modal-body-centered">
                         <img className="w-75" src="tacoAnimation.gif" alt="taco animation gif"/>
                         </ModalBody>
                     </Modal>

--- a/src/tacos.mvc/ClientApp/containers/SubmissionContainer.tsx
+++ b/src/tacos.mvc/ClientApp/containers/SubmissionContainer.tsx
@@ -121,7 +121,6 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
                 <div className="tacos-action-row tacos-action-row--end">
                     <button
                         className="tacos-btn tacos-btn--primary"
-                        id="submit-button"
                         onClick={this.onAddRequest}
                         type="button"
                     >
@@ -146,7 +145,6 @@ export default class SubmissionContainer extends React.Component<IProps, IState>
                 <div className="tacos-action-row">
                     <button
                         className="tacos-btn tacos-btn--primary"
-                        id="submit-button"
                         onClick={this.onAddRequest}
                         type="button"
                     >

--- a/src/tacos.mvc/ClientApp/css/_depends.scss
+++ b/src/tacos.mvc/ClientApp/css/_depends.scss
@@ -6,6 +6,8 @@ $sans-reg: "proxima-nova-r", serif;
 
 $primary-color: #002855;
 $secondary-color: #d2ac3a;
+$legacy-secondary-color: #c99700;
+$legacy-secondary-focus-shadow: #d6b759;
 $tertiary-color: color.adjust($secondary-color, $alpha: -0.8);
 
 $gold: #d2ac3a;

--- a/src/tacos.mvc/ClientApp/css/_regions.scss
+++ b/src/tacos.mvc/ClientApp/css/_regions.scss
@@ -1,11 +1,11 @@
 @use "depends" as *;
 
 .edit-requests {
-    &.container {
-        max-width: 80%;
+    max-width: 80%;
+    margin-left: auto;
+    margin-right: auto;
 
-        @include breakpoint(tablet) {
-            max-width: 100%;
-        }
+    @include breakpoint(tablet) {
+        max-width: 100%;
     }
 }

--- a/src/tacos.mvc/ClientApp/css/_regions.scss
+++ b/src/tacos.mvc/ClientApp/css/_regions.scss
@@ -4,6 +4,7 @@
     max-width: 80%;
     margin-left: auto;
     margin-right: auto;
+    padding-top: 2.95rem;
 
     @include breakpoint(tablet) {
         max-width: 100%;

--- a/src/tacos.mvc/ClientApp/css/_vendor.scss
+++ b/src/tacos.mvc/ClientApp/css/_vendor.scss
@@ -36,6 +36,12 @@
       margin-bottom: 1rem;
     }
 
+    .tacos-datatable-table {
+      overflow-x: auto;
+      background-color: #fff;
+      border: 1px solid #d3dbe5;
+    }
+
     .tacos-datatable-footer {
       margin-top: 1rem;
     }
@@ -113,12 +119,12 @@
     .dt-button,
     .dt-button:visited {
       align-items: center;
-      background-color: $primary-color !important;
+      background-color: #f5e0a1 !important;
       background-image: none !important;
-      border: 1px solid $primary-color !important;
+      border: 1px solid #f5e0a1 !important;
       border-radius: 0 !important;
       box-shadow: none !important;
-      color: #fff !important;
+      color: $primary-color !important;
       cursor: pointer;
       display: inline-flex;
       font: inherit;
@@ -135,11 +141,11 @@
     .dt-button:focus,
     .dt-button:focus-visible,
     .dt-button:active {
-      background-color: #2f5b8c !important;
+      background-color: #faefce !important;
       background-image: none !important;
-      border-color: #2f5b8c !important;
+      border-color: #faefce !important;
       box-shadow: none !important;
-      color: #fff !important;
+      color: $primary-color !important;
       outline: 0;
       text-decoration: none !important;
     }
@@ -353,8 +359,8 @@
           font-size: 0.875rem;
           line-height: 1;
           position: absolute;
-          right: 0.5rem;
-          bottom: 0.55rem;
+          right: 0.75rem;
+          bottom: 0.95rem;
         }
 
         &.sorting::after,
@@ -371,6 +377,55 @@
           content: "▼";
         }
       }
+    }
+
+    table.dataTable.tacos-page-table,
+    table.dataTable.tacos-page-table.no-footer {
+      border: 0 !important;
+      border-collapse: separate !important;
+      border-spacing: 0 !important;
+    }
+
+    table.dataTable.tacos-page-table tbody td,
+    table.dataTable.tacos-page-table tfoot td {
+      border-right: 1px solid #d3dbe5 !important;
+    }
+
+    table.dataTable.tacos-page-table thead th {
+      border-right: 0 !important;
+    }
+
+    table.dataTable.tacos-page-table tbody td:last-child,
+    table.dataTable.tacos-page-table tfoot td:last-child {
+      border-right: 0 !important;
+    }
+
+    table.dataTable.tacos-page-table thead th {
+      border-bottom: 0 !important;
+    }
+
+    table.dataTable.tacos-page-table tbody td,
+    table.dataTable.tacos-page-table tfoot td {
+      border-top: 1px solid #d3dbe5 !important;
+      border-bottom: 0 !important;
+    }
+
+    table.dataTable.tacos-admin-roles-table,
+    table.dataTable.tacos-admin-roles-table.no-footer {
+      border: 0 !important;
+      border-collapse: collapse !important;
+      border-spacing: 0 !important;
+    }
+
+    table.dataTable.tacos-admin-roles-table thead th {
+      border-right: 0 !important;
+      border-bottom: 2px solid $legacy-secondary-color !important;
+    }
+
+    table.dataTable.tacos-admin-roles-table tbody td {
+      border-top: 1px solid #d3dbe5 !important;
+      border-right: 0 !important;
+      border-bottom: 0 !important;
     }
   
     @media (max-width: 767px) {

--- a/src/tacos.mvc/ClientApp/css/_vendor.scss
+++ b/src/tacos.mvc/ClientApp/css/_vendor.scss
@@ -4,13 +4,382 @@
 .dataTables_wrapper {
     padding-left: 0;
     padding-right: 0;
-  
-    table {
-      
+
+    > .dataTables_length,
+    > .dataTables_filter {
+      margin-bottom: 0.75rem;
+    }
+
+    > .row:first-child {
+      margin-bottom: 0.75rem;
+    }
+
+    > .row:nth-child(2) {
+      margin-top: 0.75rem;
+    }
+
+    > table.dataTable {
+      clear: both;
+      margin-top: 0.75rem !important;
+    }
+
+    .tacos-datatable-toolbar,
+    .tacos-datatable-footer {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      justify-content: space-between;
+    }
+
+    .tacos-datatable-toolbar {
+      margin-bottom: 1rem;
+    }
+
+    .tacos-datatable-footer {
+      margin-top: 1rem;
+    }
+
+    .tacos-datatable-toolbar__actions,
+    .tacos-datatable-footer__pagination {
+      align-items: center;
+      display: flex;
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      justify-content: flex-end;
+      min-width: 16rem;
+    }
+
+    .tacos-datatable-toolbar__length,
+    .tacos-datatable-footer__info {
+      flex: 0 1 auto;
+    }
+
+    .dataTables_length,
+    .dataTables_filter,
+    .dataTables_info,
+    .dataTables_paginate,
+    .dt-buttons {
+      margin: 0;
+    }
+
+    .dataTables_length label,
+    .dataTables_filter label {
+      align-items: center;
+      color: $primary-font;
+      display: inline-flex;
+      font-size: 0.875rem;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 0;
+    }
+
+    .dataTables_length select,
+    .dataTables_filter input {
+      background-clip: padding-box;
+      background-color: #fff;
+      border: 1px solid #ced4da;
+      border-radius: 0.25rem;
+      box-shadow: none;
+      color: $primary-font;
+      font-family: inherit;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      margin: 0;
+      min-height: calc(1.5em + 0.5rem + 2px);
+      padding: 0.25rem 0.5rem;
+      transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+      &:focus {
+        border-color: $legacy-secondary-color;
+        outline: 0;
+        box-shadow: 0 0.02rem 0 0.1rem $legacy-secondary-focus-shadow;
+      }
+    }
+
+    .dataTables_length select {
+      height: auto;
+      padding-right: 2rem;
+    }
+
+    .dt-buttons {
+      align-items: center;
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .dt-button,
+    .dt-button:visited {
+      align-items: center;
+      background-color: $primary-color !important;
+      background-image: none !important;
+      border: 1px solid $primary-color !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      color: #fff !important;
+      cursor: pointer;
+      display: inline-flex;
+      font: inherit;
+      justify-content: center;
+      line-height: 1.5;
+      margin: 0 !important;
+      min-height: 0;
+      padding: 0.5em 1em !important;
+      text-decoration: none !important;
+      white-space: nowrap;
+    }
+
+    .dt-button:hover,
+    .dt-button:focus,
+    .dt-button:focus-visible,
+    .dt-button:active {
+      background-color: #2f5b8c !important;
+      background-image: none !important;
+      border-color: #2f5b8c !important;
+      box-shadow: none !important;
+      color: #fff !important;
+      outline: 0;
+      text-decoration: none !important;
+    }
+
+    .dataTables_paginate {
+      align-items: center;
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 0;
+      justify-content: flex-end;
+    }
+
+    .dataTables_paginate .pagination {
+      display: inline-flex;
+      margin: 0;
+    }
+
+    .dataTables_paginate .page-link {
+      align-items: center;
+      background: #fff !important;
+      border: 1px solid #dee2e6 !important;
+      box-shadow: none !important;
+      color: #007bff !important;
+      display: inline-flex;
+      justify-content: center;
+      line-height: 1.25;
+      margin-left: -1px;
+      min-width: 2.5rem;
+      padding: 0.375rem 0.75rem;
+      position: relative;
+      text-decoration: none !important;
+    }
+
+    .dataTables_paginate .page-item:first-child .page-link {
+      border-bottom-left-radius: 0.25rem;
+      border-top-left-radius: 0.25rem;
+      margin-left: 0;
+    }
+
+    .dataTables_paginate .page-item:last-child .page-link {
+      border-bottom-right-radius: 0.25rem;
+      border-top-right-radius: 0.25rem;
+    }
+
+    .dataTables_paginate .page-item.active .page-link {
+      background: #007bff !important;
+      border-color: #007bff !important;
+      color: #fff !important;
+      z-index: 1;
+    }
+
+    .dataTables_paginate .page-link:hover,
+    .dataTables_paginate .page-link:focus,
+    .dataTables_paginate .page-link:focus-visible,
+    .dataTables_paginate .page-link:active {
+      background: #e9ecef !important;
+      border-color: #dee2e6 !important;
+      box-shadow: none !important;
+      color: #007bff !important;
+      outline: 0;
+      text-decoration: none !important;
+    }
+
+    .dataTables_paginate .page-item.active .page-link:hover,
+    .dataTables_paginate .page-item.active .page-link:focus,
+    .dataTables_paginate .page-item.active .page-link:focus-visible,
+    .dataTables_paginate .page-item.active .page-link:active {
+      background: #007bff !important;
+      border-color: #007bff !important;
+      color: #fff !important;
+    }
+
+    .dataTables_paginate .page-item.disabled .page-link {
+      background: #fff !important;
+      border-color: #dee2e6 !important;
+      color: #6c757d !important;
+      cursor: default;
+      opacity: 1;
+    }
+
+    .dataTables_paginate > span {
+      display: inline-flex;
+    }
+
+    .dataTables_paginate .paginate_button,
+    .dataTables_paginate .paginate_button:visited,
+    .ellipsis {
+      align-items: center;
+      background: #fff !important;
+      border: 1px solid #dee2e6 !important;
+      box-shadow: none !important;
+      color: #007bff !important;
+      display: inline-flex;
+      justify-content: center;
+      line-height: 1.25;
+      margin-left: -1px !important;
+      min-width: 2.5rem;
+      padding: 0.375rem 0.75rem !important;
+      position: relative;
+      text-decoration: none !important;
+    }
+
+    .dataTables_paginate .paginate_button {
+      cursor: pointer;
+      display: inline-flex;
+    }
+
+    .ellipsis {
+      color: #6c757d !important;
+      cursor: default;
+      user-select: none;
+    }
+
+    .dataTables_paginate .paginate_button.previous {
+      border-bottom-left-radius: 0.25rem !important;
+      border-top-left-radius: 0.25rem !important;
+      margin-left: 0 !important;
+    }
+
+    .dataTables_paginate .paginate_button.next {
+      border-bottom-right-radius: 0.25rem !important;
+      border-top-right-radius: 0.25rem !important;
+    }
+
+    .dataTables_paginate .paginate_button.current,
+    .dataTables_paginate .paginate_button.current:hover,
+    .dataTables_paginate .paginate_button.current:visited {
+      background: #007bff !important;
+      border-color: #007bff !important;
+      color: #fff !important;
+      z-index: 1;
+    }
+
+    .dataTables_paginate .paginate_button:hover,
+    .dataTables_paginate .paginate_button:focus,
+    .dataTables_paginate .paginate_button:focus-visible,
+    .dataTables_paginate .paginate_button:active,
+    .dataTables_paginate .paginate_button:visited:hover {
+      background: #e9ecef !important;
+      border-color: #dee2e6 !important;
+      box-shadow: none !important;
+      color: #007bff !important;
+      outline: 0;
+      text-decoration: none !important;
+    }
+
+    .dataTables_paginate .paginate_button.disabled,
+    .dataTables_paginate .paginate_button.disabled:hover,
+    .dataTables_paginate .paginate_button.disabled:active,
+    .dataTables_paginate .paginate_button.disabled:visited,
+    .dataTables_paginate .paginate_button.disabled:visited:hover,
+    .ellipsis {
+      background: #fff !important;
+      border-color: #dee2e6 !important;
+      color: #007bff !important;
+      cursor: default !important;
+      opacity: 1;
+    }
+
+    .dataTables_paginate .paginate_button.previous.disabled,
+    .dataTables_paginate .paginate_button.previous.disabled:hover,
+    .dataTables_paginate .paginate_button.previous.disabled:active,
+    .dataTables_paginate .paginate_button.previous.disabled:visited,
+    .dataTables_paginate .paginate_button.previous.disabled:visited:hover,
+    .dataTables_paginate .paginate_button.next.disabled,
+    .dataTables_paginate .paginate_button.next.disabled:hover,
+    .dataTables_paginate .paginate_button.next.disabled:active,
+    .dataTables_paginate .paginate_button.next.disabled:visited,
+    .dataTables_paginate .paginate_button.next.disabled:visited:hover,
+    .ellipsis {
+      color: #6c757d !important;
     }
   
-    .dt-buttons:last-child {
-      padding-left: 2rem;
+    table {
+      font-size: 1rem;
+
+      thead,
+      tbody,
+      tfoot {
+        font-size: inherit;
+        white-space: normal;
+      }
+
+      th,
+      td {
+        font-size: inherit;
+        white-space: normal;
+        overflow-wrap: normal;
+        word-break: normal;
+      }
+
+      thead th {
+        vertical-align: bottom;
+
+        &.sorting,
+        &.sorting_asc,
+        &.sorting_desc,
+        &.sorting_asc_disabled,
+        &.sorting_desc_disabled {
+          background-image: none !important;
+          padding-right: 1.75rem !important;
+          position: relative;
+        }
+
+        &.sorting::after,
+        &.sorting_asc::after,
+        &.sorting_desc::after,
+        &.sorting_asc_disabled::after,
+        &.sorting_desc_disabled::after {
+          color: $secondary-font;
+          font-size: 0.875rem;
+          line-height: 1;
+          position: absolute;
+          right: 0.5rem;
+          bottom: 0.55rem;
+        }
+
+        &.sorting::after,
+        &.sorting_asc_disabled::after,
+        &.sorting_desc_disabled::after {
+          content: "↕";
+        }
+
+        &.sorting_asc::after {
+          content: "▲";
+        }
+
+        &.sorting_desc::after {
+          content: "▼";
+        }
+      }
+    }
+  
+    @media (max-width: 767px) {
+      .tacos-datatable-toolbar,
+      .tacos-datatable-footer,
+      .tacos-datatable-toolbar__actions,
+      .tacos-datatable-footer__pagination {
+        justify-content: flex-start;
+      }
     }
 }
 
@@ -21,8 +390,8 @@ table.requests {
   }
 
   .requests-filter-row {
-    input.form-control,
-    select.custom-select {
+    input.tacos-input,
+    select.tacos-select {
       font-family: inherit;
       font-size: inherit;
       height: calc(1.5em + 0.65rem + 2px);
@@ -44,7 +413,7 @@ table.requests {
     min-height: calc(1.5em + 0.65rem + 2px);
   }
 
-  .requests-filter-row select.custom-select {
+  .requests-filter-row select.tacos-select {
     background: #fff url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") no-repeat right 0.75rem center;
     background-size: 8px 10px;
   }
@@ -53,14 +422,14 @@ table.requests {
     vertical-align: top;
   }
 
-  .requests-filter-row .input-group,
+  .requests-filter-row .requests-filter-control,
   .requests-filter-row > th > div {
     width: 100%;
   }
 
-  td .form-control,
-  td .custom-select,
-  td textarea.form-control {
+  td .tacos-input,
+  td .tacos-select,
+  td textarea.tacos-textarea {
     font-family: inherit;
     font-size: inherit;
   }

--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -11,59 +11,629 @@ html {
   scroll-behavior: smooth;
 }
 
-// // fonts
-@font-face {
-  font-family: "proxima-nova-r";
-  src: url("../media/proximanova-regular-webfont.woff") format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face {
-  font-family: "proxima-nova-i";
-  src: url("../media/proximanova-regularit-webfont.woff") format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face {
-  font-family: "proxima-nova-b";
-  src: url("../media/proximanova-bold-webfont.woff") format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
+// Proxima Nova font faces are provided by the Gunrock import in `main.css`.
+// Duplicating them here with local relative URLs causes dev font requests to
+// fall through to the ASP.NET SPA proxy.
 
 
 
 // fix stupid ucdavis styles
 .btn {
+  border-radius: 0;
+  box-shadow: none;
+  height: auto;
+  min-height: 0;
+  padding: 0.5rem 1rem;
+  line-height: 1.5;
+
   &.btn-link {
     border: none;
   }
+
+  &:hover,
+  &:active,
+  &:focus,
+  &:focus-visible {
+    box-shadow: none;
+  }
+}
+
+.tacos-section-gap {
+  margin-bottom: 1.5rem;
+}
+
+.tacos-page-with-summary {
+  padding-bottom: 6rem;
+}
+
+.tacos-action-row {
+  display: flex;
+  margin-bottom: 1.5rem;
+}
+
+.tacos-action-row--end {
+  justify-content: flex-end;
+}
+
+.tacos-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1.5;
+  min-height: 0;
+  padding: 0.5em 1em;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover,
+  &:focus,
+  &:focus-visible,
+  &:active {
+    box-shadow: none;
+    text-decoration: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(0, 123, 255, 0.25);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+  }
+}
+
+.tacos-btn--primary {
+  background-color: $primary-color;
+  border-color: $primary-color;
+  color: #fff;
+
+  &:hover,
+  &:active {
+    background-color: #2f5b8c;
+    border-color: #2f5b8c;
+    color: #fff;
+  }
+
+  &:disabled {
+    background-color: transparent;
+    border-color: $primary-color;
+    color: $primary-color;
+    opacity: 1;
+  }
+}
+
+.tacos-btn--secondary {
+  background-color: #f5e0a1;
+  border-color: transparent;
+  color: #004088;
+
+  &:hover,
+  &:active {
+    background-color: #faefce;
+    border-color: transparent;
+    color: #004088;
+  }
+
+  &:disabled {
+    background-color: transparent;
+    border-color: #f5e0a1;
+    color: #004088;
+    opacity: 1;
+  }
+}
+
+.tacos-btn--danger {
+  background-color: #ba0c2f;
+  border-color: #ba0c2f;
+  color: #fff;
+
+  &:hover,
+  &:active {
+    background-color: #f60334;
+    border-color: #f60334;
+    color: #fff;
+  }
+
+  &:disabled {
+    background-color: transparent;
+    border-color: #ba0c2f;
+    color: #ba0c2f;
+    opacity: 1;
+  }
+}
+
+.tacos-btn--icon-only {
+  padding-top: 0.82em;
+  padding-bottom: 0.82em;
+  padding-left: 1.065em;
+  padding-right: 1.065em;
+
+  > .fa,
+  > .far,
+  > .fas {
+    font-size: 1rem;
+    line-height: 1;
+  }
+}
+
+.tacos-btn__icon {
+  margin-left: 0.5rem;
+}
+
+.tacos-inline-icon-start {
+  margin-right: 0.75rem;
+}
+
+.tacos-form-field {
+  margin-bottom: 1rem;
+}
+
+.tacos-form-label {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+}
+
+.tacos-input,
+.tacos-select,
+.tacos-textarea {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0.375rem 0.75rem;
+  color: $primary-font;
+  font: inherit;
+  line-height: 1.5;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+  &:focus {
+    border-color: $legacy-secondary-color;
+    outline: 0;
+    box-shadow: 0 0.02rem 0 0.1rem $legacy-secondary-focus-shadow;
+  }
+}
+
+form .form-control:focus,
+form .form-control.focus {
+  border-color: $legacy-secondary-color;
+  box-shadow: 0 0.02rem 0 0.1rem $legacy-secondary-focus-shadow;
+}
+
+.tacos-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E");
+  background-position: right 0.75rem center;
+  background-repeat: no-repeat;
+  background-size: 8px 10px;
+  cursor: pointer;
+  padding-right: 2rem;
+}
+
+.tacos-textarea {
+  min-height: calc(1.5em * 3 + 0.75rem + 2px);
+  resize: vertical;
+}
+
+.tacos-input-group {
+  display: flex;
+  width: 100%;
+
+  > .tacos-input {
+    flex: 1 1 auto;
+    min-width: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+.tacos-input-group__addon {
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  background-color: $accent;
+  border: 1px solid #ced4da;
+  border-left: 0;
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.tacos-input-group__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1rem;
+}
+
+.tacos-form-help {
+  display: block;
+  margin-top: 0.25rem;
+  padding-left: 0.5rem;
+}
+
+.tacos-form-help--muted {
+  color: $secondary-font;
+}
+
+.tacos-form-help__message {
+  margin-right: 0.75rem;
+}
+
+.tacos-link-button {
+  padding: 0;
+  color: $a-link;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  font: inherit;
+  line-height: inherit;
+  text-decoration: underline;
+
+  &:hover,
+  &:focus,
+  &:focus-visible,
+  &:active {
+    color: $a-link;
+    box-shadow: none;
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(0, 123, 255, 0.25);
+    outline-offset: 2px;
+  }
+}
+
+.tacos-link-button--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tacos-truncate {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tacos-text-warning {
+  color: #856404;
+}
+
+.tacos-text-danger {
+  color: #dc3545;
+}
+
+// DaisyUI also defines a `.navbar` component. Isolate the UCD banner so its
+// pseudo-element background stays behind the logo instead of falling behind the page.
+.navbar.navbar-default .navbar-banner,
+.navbar.navbar-inverted .navbar-banner {
+  isolation: isolate;
+}
+
+body > nav.navbar.navbar-default,
+body > nav.navbar.navbar-inverted {
+  min-height: 0;
+}
+
+body > nav.navbar.navbar-default .navbar-banner,
+body > nav.navbar.navbar-inverted .navbar-banner {
+  display: flex;
+  align-items: flex-end;
+  padding-top: 0.75em;
+  padding-bottom: 0.49em;
+}
+
+body > nav.navbar.navbar-default .navbar-banner .navbar-brand,
+body > nav.navbar.navbar-inverted .navbar-banner .navbar-brand {
+  position: relative;
+  top: 0;
+}
+
+body.tacos-modal-open {
+  overflow: hidden;
+}
+
+dialog.tacos-dialog {
+  pointer-events: none;
+  visibility: hidden;
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  display: grid;
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+  margin: 0;
+  padding: 1.75rem 0.5rem;
+  overflow: clip;
+  background: transparent;
+  background-color: transparent !important;
+  border: 0;
+  place-items: center;
+}
+
+dialog.tacos-dialog[open] {
+  pointer-events: auto;
+  visibility: visible;
+  background: transparent;
+  background-color: transparent !important;
+}
+
+dialog.tacos-dialog::backdrop {
+  display: block;
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+dialog.tacos-dialog.modal-top {
+  align-items: center;
+  justify-items: center;
+}
+
+dialog.tacos-dialog.modal-middle {
+  align-items: center;
+  justify-items: center;
+}
+
+dialog.tacos-dialog .modal-box.tacos-modal__content {
+  width: 100%;
+  max-width: 500px;
+  padding: 0;
+  opacity: 1;
+  translate: 0;
+  scale: 1;
+}
+
+dialog.tacos-dialog .modal-backdrop {
+  background: transparent;
+  color: transparent;
+  z-index: -1;
+  grid-row-start: 1;
+  grid-column-start: 1;
+  place-self: stretch;
+  display: grid;
+}
+
+dialog.tacos-dialog .modal-backdrop button {
+  cursor: pointer;
+}
+
+.tacos-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 1.75rem 0.5rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.tacos-modal[hidden] {
+  display: none !important;
+}
+
+.tacos-modal--centered {
+  align-items: center;
+}
+
+.tacos-modal__dialog {
+  width: 100%;
+  max-width: 500px;
+  outline: none;
+}
+
+.tacos-modal__content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  background-color: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0.3rem;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+
+.tacos-modal__header,
+.tacos-modal__body,
+.tacos-modal__footer {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.tacos-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.tacos-modal__title {
+  margin: 0;
+  color: inherit;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.tacos-modal__body {
+  position: relative;
+  flex: 1 1 auto;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.tacos-modal__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  border-top: 1px solid #dee2e6;
+}
+
+.tacos-modal__close {
+  flex-shrink: 0;
+  padding: 0;
+  color: #000;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  cursor: pointer;
+  opacity: 0.5;
+
+  &:hover,
+  &:focus,
+  &:focus-visible,
+  &:active {
+    color: #000;
+    box-shadow: none;
+    opacity: 0.75;
+    text-decoration: none;
+  }
+}
+
+.tacos-modal-footer--split {
+  justify-content: space-between;
+  width: 100%;
+}
+
+.tacos-modal-body-centered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tacos-tooltip {
+  max-width: 16rem;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.tacos-alert__close {
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  cursor: pointer;
+  opacity: 0.65;
+
+  &:hover,
+  &:focus,
+  &:focus-visible,
+  &:active {
+    box-shadow: none;
+    opacity: 1;
+  }
+}
+
+.tacos-tooltip__content {
+  position: relative;
+  width: max-content;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  color: #fff;
+  text-align: center;
+  white-space: normal;
+  background-color: rgba(0, 0, 0, 0.85);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.18);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.tacos-tooltip__content::after {
+  content: "";
+  position: absolute;
+  width: 0.625rem;
+  height: 0.625rem;
+  background-color: inherit;
+  transform: rotate(45deg);
+}
+
+.tacos-tooltip[data-placement="top"] .tacos-tooltip__content::after {
+  left: 50%;
+  bottom: -0.3125rem;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tacos-tooltip[data-placement="right"] .tacos-tooltip__content::after {
+  top: 50%;
+  left: -0.3125rem;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.tacos-tooltip[data-placement="bottom"] .tacos-tooltip__content::after {
+  left: 50%;
+  top: -0.3125rem;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.tacos-tooltip[data-placement="left"] .tacos-tooltip__content::after {
+  top: 50%;
+  right: -0.3125rem;
+  transform: translateY(-50%) rotate(45deg);
 }
 
 .table {
+    font-size: 1rem;
     margin-top: 3rem;
     margin-bottom: 5rem;
+    border-radius: 0;
 
+    thead,
+    tbody,
+    tfoot {
+        font-size: inherit;
+        color: $primary-font;
+    }
+
+    th,
     td {
+        font-size: inherit;
         vertical-align: baseline;
     }
+}
+
+dt {
+  font-size: 0.965rem;
+}
+
+dd {
+  margin-bottom: 0.5rem;
 }
 
 .target-flash {
   animation: background-flash 1000ms 2 ease 1000ms;
 }
 
-.input-group-text{
-background-color: $accent;
-}
-
- 
-#submit-button{
-margin-left: 4px;
-}
-
 .exceptionRow {
   background-color: $accent;
+  margin-bottom: 1.5rem;
   padding: 0.75rem;
 
   p {
@@ -73,8 +643,55 @@ margin-left: 4px;
   }
 }
 
+.exceptionRow--approved {
+  display: flex;
+  align-items: flex-start;
+}
+
+.exceptionRow__revoke {
+  margin-left: 0.5rem;
+}
+
 .exceptionRowComponents {
   margin-top: 2px;
+}
+
+.tacos-summary-bar {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  min-height: 0;
+  z-index: 1030;
+}
+
+.tacos-summary-bar__content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.tacos-summary-bar__title {
+  margin-right: auto;
+}
+
+.tacos-summary-bar__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.tacos-summary-bar__actions .tacos-btn {
+  font-size: 1rem;
+}
+
+.requests-table-scroll {
+  overflow-x: auto;
 }
 
 
@@ -96,7 +713,7 @@ table.requests {
 
   thead th {
     background-color: #fff;
-    color: inherit;
+    color: $primary-font;
     font-family: inherit;
     font-size: inherit;
     font-weight: 400;
@@ -153,6 +770,12 @@ table.requests {
     justify-self: center;
   }
 
+  thead tr:first-child th > .requests-header-cell-content > .requests-header-cell-label {
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+  }
+
   thead tr:first-child th > .requests-header-cell-content > .requests-sort-button {
     grid-column: 3;
     justify-self: end;
@@ -173,6 +796,15 @@ table.requests {
     border-top: 1px solid rgba($primary-color, 0.08);
   }
 
+  tbody td.requests-cell--center,
+  thead th.requests-header-cell--center {
+    text-align: center;
+  }
+
+  tbody td.requests-cell--middle {
+    vertical-align: middle;
+  }
+
   tbody tr:first-child td {
     border-top: 0;
   }
@@ -187,13 +819,23 @@ table.requests {
   }
 
   .requests-sort-button {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
     color: $secondary-font;
+    cursor: pointer;
     display: inline-flex;
     align-items: center;
+    font-size: inherit;
+    height: auto;
     justify-content: center;
+    margin: 0;
+    min-height: 0;
     position: relative;
     min-width: 1.25rem;
     line-height: 1;
+    padding: 0;
     text-decoration: none;
     vertical-align: top;
     z-index: 5;
@@ -225,15 +867,24 @@ table.requests {
   }
 
   .requests-icon-button {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
     color: inherit;
+    cursor: pointer;
     display: inline-flex;
     align-items: center;
+    font-size: inherit;
+    height: auto;
     justify-content: center;
     line-height: 1;
-    min-height: 1rem;
+    margin: 0;
+    min-height: 0;
     min-width: 1rem;
-    padding-top: 1px;
+    padding: 0;
     text-decoration: none;
+    vertical-align: baseline;
 
     &:hover {
       color: inherit;
@@ -250,6 +901,10 @@ table.requests {
     }
   }
 
+  thead th a {
+    color: $a-link;
+  }
+
   .requests-detail-row td {
     background-color: transparent;
     border-top: 0;
@@ -257,8 +912,45 @@ table.requests {
     vertical-align: top;
   }
 
+  .requests-detail-cell {
+    padding: 0 !important;
+  }
+
   .requests-empty-state {
     padding: 0.55rem 5px;
+  }
+
+  .requests-empty-state--muted {
+    color: $secondary-font;
+    text-align: center;
+  }
+
+  .requests-header-inline {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+  }
+
+  .requests-filter-control {
+    width: 100%;
+  }
+
+  .requests-search-filter {
+    position: relative;
+  }
+
+  .requests-search-filter__icon {
+    color: $tertiary-font;
+    pointer-events: none;
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .requests-filter-input {
+    padding-right: 2rem;
   }
 
   a {

--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -321,14 +321,6 @@ form .form-control.focus {
   color: $secondary-font;
 }
 
-// DaisyUI also defines a `.navbar` component. Keep the React summary bar's
-// pseudo-element background in the correct stacking context while the summary
-// bar still uses the UCD navbar naming.
-.navbar.navbar-default .navbar-banner,
-.navbar.navbar-inverted .navbar-banner {
-  isolation: isolate;
-}
-
 .tacos-site-nav {
   display: flex;
   flex-wrap: wrap;
@@ -340,7 +332,7 @@ form .form-control.focus {
   display: flex;
   align-items: flex-end;
   flex-basis: 100%;
-  padding: 0.75rem 1rem 0.49rem;
+  padding: 1.25rem 1.25rem 0.95rem;
   font-size: 1.25rem;
   color: #fff;
   isolation: isolate;
@@ -400,7 +392,8 @@ form .form-control.focus {
   width: 100%;
   color: $primary-color;
   background-color: #fff;
-  box-shadow: 0 2px 1px rgba(0, 40, 85, 0.15);
+  border-bottom: 1px solid #d3dbe5;
+  box-shadow: none;
 }
 
 .tacos-site-nav__panel.is-open {
@@ -418,8 +411,10 @@ form .form-control.focus {
 
 .tacos-site-nav__link {
   display: block;
-  padding: 1em 1.5em;
+  padding: 1rem 1.5rem;
   color: $primary-color;
+  font-size: 0.965rem;
+  line-height: 1.55;
   border-radius: 0;
   text-decoration: none;
 }
@@ -434,12 +429,14 @@ form .form-control.focus {
 }
 
 .tacos-site-nav__link--active {
-  background-color: #f5e0a1;
+  background-color: transparent;
 }
 
 .tacos-site-nav__user {
   padding: 0 1.5rem 1rem;
   color: $primary-color;
+  font-size: 1rem;
+  line-height: 1.55;
   white-space: nowrap;
 }
 
@@ -551,6 +548,221 @@ form .form-control.focus {
   text-align: center;
 }
 
+hr {
+  border: 0;
+  border-top: 1px solid #d3dbe5;
+  margin: 0;
+}
+
+.tacos-page-shell {
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 2.75rem 1rem 1.5rem;
+}
+
+.tacos-page-shell--full {
+  max-width: none;
+}
+
+.tacos-page-shell--flash {
+  padding-top: 1rem;
+  padding-bottom: 0;
+}
+
+.tacos-page-stack > * + * {
+  margin-top: 1.5rem;
+}
+
+.tacos-page-stack > .tacos-page-divider + * {
+  margin-top: 0.75rem;
+}
+
+.tacos-page-divider {
+  border-top-color: #d3dbe5;
+}
+
+.tacos-page-form-field {
+  width: 100%;
+}
+
+.tacos-page-form-field .tacos-select {
+  width: 100%;
+}
+
+.tacos-page-heading {
+  margin: 0;
+  color: #0b3262;
+  font-size: 2.35rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.tacos-page-meta {
+  margin: 0;
+  color: $primary-font;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.tacos-link-list {
+  margin: 0;
+  padding-left: 1.5rem;
+  list-style: disc;
+}
+
+.tacos-link-list li + li {
+  margin-top: 0.35rem;
+}
+
+.tacos-link-list a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.tacos-link-list a:hover,
+.tacos-link-list a:focus,
+.tacos-link-list a:focus-visible {
+  color: #0056b3;
+  text-decoration: underline;
+}
+
+.tacos-page-table {
+  width: 100%;
+  margin-bottom: 0;
+  background-color: #fff;
+  border: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 1rem;
+}
+
+.tacos-page-table-frame {
+  overflow-x: auto;
+  background-color: #fff;
+  border: 1px solid #d3dbe5;
+}
+
+.tacos-page-table-frame > .tacos-page-table {
+  min-width: 100%;
+}
+
+.tacos-page-table thead,
+.tacos-page-table tbody,
+.tacos-page-table tfoot {
+  color: $primary-font;
+}
+
+.tacos-page-table th,
+.tacos-page-table td {
+  padding: 0.9rem 0.8rem;
+  font-size: inherit;
+  vertical-align: middle;
+  border-right: 1px solid #d3dbe5;
+}
+
+.tacos-page-table th:last-child,
+.tacos-page-table td:last-child {
+  border-right: 0;
+}
+
+.tacos-page-table thead th {
+  font-weight: 700;
+  background-color: #fff;
+  border-bottom: 0;
+}
+
+.tacos-page-table tbody td {
+  border-top: 1px solid #d3dbe5;
+  border-bottom: 0;
+}
+
+.tacos-page-table tfoot td {
+  font-weight: 700;
+  background-color: #f6f8fb;
+  border-top: 1px solid #d3dbe5;
+  border-bottom: 0;
+}
+
+.tacos-page-table__summary td {
+  background-color: #f6f8fb;
+}
+
+.tacos-page-table tfoot .tacos-page-table__summary--info td {
+  background-color: #bee5eb;
+}
+
+.tacos-page-table a:not(.tacos-btn) {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.tacos-page-table a:not(.tacos-btn):hover,
+.tacos-page-table a:not(.tacos-btn):focus,
+.tacos-page-table a:not(.tacos-btn):focus-visible {
+  color: #0056b3;
+  text-decoration: underline;
+}
+
+.tacos-page-table__actions {
+  text-align: center;
+}
+
+.tacos-admin-roles-table {
+  width: 100%;
+  margin-bottom: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-size: 1rem;
+}
+
+.tacos-admin-roles-table thead th,
+.tacos-admin-roles-table tbody td {
+  padding: 0.9rem 0.8rem;
+  font-size: inherit;
+}
+
+.tacos-admin-roles-table thead th {
+  font-weight: 700;
+  background-color: #fff;
+  border-right: 0;
+  border-bottom: 2px solid $legacy-secondary-color;
+  vertical-align: bottom;
+}
+
+.tacos-admin-roles-table tbody tr:nth-child(odd) {
+  background-color: #f3f3f0;
+}
+
+.tacos-admin-roles-table tbody td {
+  border-top: 1px solid #d3dbe5;
+  border-right: 0;
+}
+
+.tacos-admin-roles-table tbody tr:first-child td {
+  border-top: 0;
+}
+
+.tacos-system-roles-table tbody td {
+  vertical-align: top;
+}
+
+.tacos-system-roles-table__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.tacos-system-roles-table__actions-divider {
+  width: 100%;
+  height: 1px;
+  background-color: #d3dbe5;
+}
+
+.tacos-department-roles-table tbody td {
+  vertical-align: middle;
+}
+
 @media (max-width: 767px) {
   .tacos-home-panel {
     padding-top: 3rem;
@@ -611,17 +823,17 @@ dialog.tacos-dialog::backdrop {
   background-color: rgba(0, 0, 0, 0.45);
 }
 
-dialog.tacos-dialog.modal-top {
+dialog.tacos-dialog--top {
   align-items: center;
   justify-items: center;
 }
 
-dialog.tacos-dialog.modal-middle {
+dialog.tacos-dialog--middle {
   align-items: center;
   justify-items: center;
 }
 
-dialog.tacos-dialog .modal-box.tacos-modal__content {
+dialog.tacos-dialog .tacos-dialog__panel.tacos-modal__content {
   width: 100%;
   max-width: 500px;
   padding: 0;
@@ -630,7 +842,7 @@ dialog.tacos-dialog .modal-box.tacos-modal__content {
   scale: 1;
 }
 
-dialog.tacos-dialog .modal-backdrop {
+dialog.tacos-dialog .tacos-dialog__backdrop {
   background: transparent;
   color: transparent;
   z-index: -1;
@@ -640,7 +852,7 @@ dialog.tacos-dialog .modal-backdrop {
   display: grid;
 }
 
-dialog.tacos-dialog .modal-backdrop button {
+dialog.tacos-dialog .tacos-dialog__backdrop button {
   cursor: pointer;
 }
 
@@ -853,6 +1065,7 @@ dialog.tacos-dialog .modal-backdrop button {
 
 dt {
   font-size: 0.965rem;
+  font-weight: 700;
 }
 
 dd {
@@ -897,17 +1110,37 @@ dd {
   z-index: 1030;
 }
 
+.tacos-summary-bar__banner {
+  font-size: 1.25rem;
+  padding: 0.5em 1em;
+  position: relative;
+  color: #fff;
+  isolation: isolate;
+}
+
+.tacos-summary-bar__banner::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background: url("https://ucdcdn.azureedge.net/public/media/global-header-bg.svg"),
+    linear-gradient(to right, #183357, #d9b337);
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
 .tacos-summary-bar__content {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
 .tacos-summary-bar__title {
   margin-right: auto;
+  color: inherit;
+  font-size: inherit;
+  line-height: 1.2;
 }
 
 .tacos-summary-bar__actions {

--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -317,30 +317,262 @@ form .form-control.focus {
   color: #dc3545;
 }
 
-// DaisyUI also defines a `.navbar` component. Isolate the UCD banner so its
-// pseudo-element background stays behind the logo instead of falling behind the page.
+.tacos-text-muted {
+  color: $secondary-font;
+}
+
+// DaisyUI also defines a `.navbar` component. Keep the React summary bar's
+// pseudo-element background in the correct stacking context while the summary
+// bar still uses the UCD navbar naming.
 .navbar.navbar-default .navbar-banner,
 .navbar.navbar-inverted .navbar-banner {
   isolation: isolate;
 }
 
-body > nav.navbar.navbar-default,
-body > nav.navbar.navbar-inverted {
-  min-height: 0;
+.tacos-site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0;
 }
 
-body > nav.navbar.navbar-default .navbar-banner,
-body > nav.navbar.navbar-inverted .navbar-banner {
+.tacos-site-nav__banner {
+  position: relative;
   display: flex;
   align-items: flex-end;
-  padding-top: 0.75em;
-  padding-bottom: 0.49em;
+  flex-basis: 100%;
+  padding: 0.75rem 1rem 0.49rem;
+  font-size: 1.25rem;
+  color: #fff;
+  isolation: isolate;
 }
 
-body > nav.navbar.navbar-default .navbar-banner .navbar-brand,
-body > nav.navbar.navbar-inverted .navbar-banner .navbar-brand {
-  position: relative;
-  top: 0;
+.tacos-site-nav__banner::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background: url("https://ucdcdn.azureedge.net/public/media/global-header-bg.svg"),
+    linear-gradient(to right, #183357, #d9b337);
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.tacos-site-nav__brand {
+  display: block;
+  max-width: 10em;
+  font-size: inherit;
+}
+
+.tacos-site-nav__brand img {
+  display: block;
+  max-width: 100%;
+}
+
+.tacos-site-nav__toggle {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.75rem;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  color: #fff;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  cursor: pointer;
+}
+
+.tacos-site-nav__toggle:hover,
+.tacos-site-nav__toggle:focus,
+.tacos-site-nav__toggle:focus-visible,
+.tacos-site-nav__toggle:active {
+  color: #fff;
+  background: transparent;
+  box-shadow: none;
+}
+
+.tacos-site-nav__panel {
+  display: none;
+  width: 100%;
+  color: $primary-color;
+  background-color: #fff;
+  box-shadow: 0 2px 1px rgba(0, 40, 85, 0.15);
+}
+
+.tacos-site-nav__panel.is-open {
+  display: block;
+}
+
+.tacos-site-nav__inner {
+  display: flex;
+  flex-direction: column;
+}
+
+.tacos-site-nav__links {
+  width: 100%;
+}
+
+.tacos-site-nav__link {
+  display: block;
+  padding: 1em 1.5em;
+  color: $primary-color;
+  border-radius: 0;
+  text-decoration: none;
+}
+
+.tacos-site-nav__link:hover,
+.tacos-site-nav__link:focus,
+.tacos-site-nav__link:focus-visible,
+.tacos-site-nav__link:active {
+  color: $primary-color;
+  background-color: $legacy-secondary-color;
+  text-decoration: none;
+}
+
+.tacos-site-nav__link--active {
+  background-color: #f5e0a1;
+}
+
+.tacos-site-nav__user {
+  padding: 0 1.5rem 1rem;
+  color: $primary-color;
+  white-space: nowrap;
+}
+
+@media (min-width: 992px) {
+  .tacos-site-nav__toggle {
+    display: none;
+  }
+
+  .tacos-site-nav__panel {
+    display: block;
+  }
+
+  .tacos-site-nav__inner {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 1rem;
+  }
+
+  .tacos-site-nav__links {
+    width: auto;
+    flex: 1 1 auto;
+  }
+
+  .tacos-site-nav__user {
+    padding: 0;
+    margin-left: 1rem;
+    text-align: right;
+    flex: 0 0 auto;
+  }
+}
+
+.tacos-home-panel {
+  background-color: #eef1f6;
+  padding: 5.5rem 1rem 6rem;
+}
+
+.tacos-home-panel__content {
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.tacos-home-panel__intro {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+.tacos-home-panel__title {
+  color: #002f6c;
+  font-size: clamp(3.5rem, 6vw, 4.75rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  margin: 0 0 1.5rem;
+}
+
+.tacos-home-panel__subtitle {
+  color: #4d4d4d;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.tacos-home-panel__body {
+  max-width: 70rem;
+  margin: 0 auto;
+  color: $primary-font;
+  font-size: 1.15rem;
+  line-height: 1.75;
+}
+
+.tacos-home-panel__body p {
+  margin: 0 0 1.25rem;
+}
+
+.tacos-home-panel__section-title {
+  color: #0b3262;
+  font-size: 2.1rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 1rem;
+}
+
+.tacos-home-panel__section-title--link a {
+  color: #0f6ddf;
+  text-decoration: none;
+}
+
+.tacos-home-panel__section-title--link a:hover,
+.tacos-home-panel__section-title--link a:focus,
+.tacos-home-panel__section-title--link a:focus-visible {
+  color: #0f6ddf;
+  text-decoration: underline;
+}
+
+.tacos-home-panel__timeline {
+  list-style: none;
+  margin: 0 0 1.75rem;
+  padding: 0;
+}
+
+.tacos-home-panel__timeline li {
+  margin-bottom: 0.15rem;
+}
+
+.tacos-home-panel__actions {
+  margin-top: 2.25rem;
+  text-align: center;
+}
+
+@media (max-width: 767px) {
+  .tacos-home-panel {
+    padding-top: 3rem;
+    padding-bottom: 3.5rem;
+  }
+
+  .tacos-home-panel__intro {
+    margin-bottom: 2rem;
+  }
+
+  .tacos-home-panel__subtitle {
+    font-size: 1.4rem;
+  }
+
+  .tacos-home-panel__body {
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+
+  .tacos-home-panel__section-title {
+    font-size: 1.8rem;
+  }
 }
 
 body.tacos-modal-open {

--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -798,6 +798,7 @@ dialog.tacos-dialog {
   inset: 0;
   z-index: 1050;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   width: 100%;
   max-width: none;
   height: 100%;
@@ -808,7 +809,10 @@ dialog.tacos-dialog {
   background: transparent;
   background-color: transparent !important;
   border: 0;
-  place-items: center;
+  align-items: start;
+  justify-items: center;
+  align-content: start;
+  justify-content: center;
 }
 
 dialog.tacos-dialog[open] {
@@ -824,12 +828,12 @@ dialog.tacos-dialog::backdrop {
 }
 
 dialog.tacos-dialog--top {
-  align-items: center;
+  align-items: start;
   justify-items: center;
 }
 
 dialog.tacos-dialog--middle {
-  align-items: center;
+  align-items: start;
   justify-items: center;
 }
 
@@ -840,12 +844,14 @@ dialog.tacos-dialog .tacos-dialog__panel.tacos-modal__content {
   opacity: 1;
   translate: 0;
   scale: 1;
+  position: relative;
+  z-index: 1;
 }
 
 dialog.tacos-dialog .tacos-dialog__backdrop {
   background: transparent;
   color: transparent;
-  z-index: -1;
+  z-index: 0;
   grid-row-start: 1;
   grid-column-start: 1;
   place-self: stretch;
@@ -853,6 +859,13 @@ dialog.tacos-dialog .tacos-dialog__backdrop {
 }
 
 dialog.tacos-dialog .tacos-dialog__backdrop button {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  color: transparent;
   cursor: pointer;
 }
 
@@ -871,10 +884,6 @@ dialog.tacos-dialog .tacos-dialog__backdrop button {
 
 .tacos-modal[hidden] {
   display: none !important;
-}
-
-.tacos-modal--centered {
-  align-items: center;
 }
 
 .tacos-modal__dialog {

--- a/src/tacos.mvc/ClientApp/main.css
+++ b/src/tacos.mvc/ClientApp/main.css
@@ -1,0 +1,3 @@
+@import "tailwindcss";
+@plugin "daisyui";
+@import "@ucdavis/gunrock-tailwind/imports.css";

--- a/src/tacos.mvc/ClientApp/main.css
+++ b/src/tacos.mvc/ClientApp/main.css
@@ -1,3 +1,4 @@
 @import "tailwindcss";
 @plugin "daisyui";
 @import "@ucdavis/gunrock-tailwind/imports.css";
+@source "../Views";

--- a/src/tacos.mvc/ClientApp/pages/EditSubmission.tsx
+++ b/src/tacos.mvc/ClientApp/pages/EditSubmission.tsx
@@ -6,6 +6,7 @@ import SubmissionContainer from "../containers/SubmissionContainer";
 import { IDepartment } from "../models/IDepartment";
 import { IRequest } from "../models/IRequest";
 
+import "../main.css";
 import "../css/site.scss";
 
 declare var department: IDepartment;

--- a/src/tacos.mvc/ClientApp/pages/EditSubmission.tsx
+++ b/src/tacos.mvc/ClientApp/pages/EditSubmission.tsx
@@ -9,8 +9,8 @@ import { IRequest } from "../models/IRequest";
 import "../main.css";
 import "../css/site.scss";
 
-declare var department: IDepartment;
-declare var model: IRequest[];
+declare const department: IDepartment;
+declare const model: IRequest[];
 
 function renderApp() {
     const appElement = document.getElementById("react-app");

--- a/src/tacos.mvc/ClientApp/util/formulas.ts
+++ b/src/tacos.mvc/ClientApp/util/formulas.ts
@@ -42,7 +42,7 @@ const writingLectureFormula: IFormula = {
         }
 
         // "Discussion sections average 20-25 students
-        // Half-time TA is responsible for 2 discussion sections, i.e. 40 students"
+        // Half-time TA is responsible for 2 discussion sections, i.e. 40 students"
         return roundTo((sectionsPerCourse / 2.0) * 0.5, 0.5);
     }
 };
@@ -57,8 +57,8 @@ const labFormula: IFormula = {
         }
 
         // "Lab/studio sections average 15-20 students
-        // Half-time TA is responsible for 2 lab/studio sections, i.e. 25-30 students
-        // Alternative: 10-15 students per section if room size, equipment, or safety concerns require"
+        // Half-time TA is responsible for 2 lab/studio sections, i.e. 25-30 students
+        // Alternative: 10-15 students per section if room size, equipment, or safety concerns require"
         return roundTo((course.averageEnrollment / 30.0) * 0.5, 0.5);
     }
 };
@@ -118,8 +118,8 @@ const lectureModerateWritingFormula: IFormula = {
     }
 };
 
-// "Lecture-only classes, writing-intensive or substantial project
-// (No sections; GE writing or ≥10 page papers: ' substantial project’ is a project that comprises at least 25% of the total course grade and requires input from faculty/TA’s over more than one class meeting for organization, planning, implementation, and/or evaluation/grading of student work"
+// "Lecture-only classes, writing-intensive or substantial project
+// (No sections; GE writing or >=10 page papers: 'substantial project' is a project that comprises at least 25% of the total course grade and requires input from faculty/TA's over more than one class meeting for organization, planning, implementation, and/or evaluation/grading of student work"
 const lectureIntensiveFormula: IFormula = {
     calculate: (course: ICourse) => {
         // 25% TA or Reader per 40 students for courses with 40 or more students

--- a/src/tacos.mvc/Views/Account/AccessDenied.cshtml
+++ b/src/tacos.mvc/Views/Account/AccessDenied.cshtml
@@ -3,6 +3,12 @@
 }
 
 <header>
-    <h2 class="text-danger">ViewData["Title"]</h2>
-    <p class="text-danger">You do not have access to this resource.</p>
+    <div class="mx-auto max-w-3xl px-4 py-10">
+        <div class="alert alert-error rounded-none shadow-sm">
+            <div>
+                <h2 class="text-xl font-semibold">@ViewData["Title"]</h2>
+                <p>You do not have access to this resource.</p>
+            </div>
+        </div>
+    </div>
 </header>

--- a/src/tacos.mvc/Views/Account/Lockout.cshtml
+++ b/src/tacos.mvc/Views/Account/Lockout.cshtml
@@ -3,6 +3,12 @@
 }
 
 <header>
-    <h2 class="text-danger">@ViewData["Title"]</h2>
-    <p class="text-danger">This account has been locked out, please try again later.</p>
+    <div class="mx-auto max-w-3xl px-4 py-10">
+        <div class="alert alert-error rounded-none shadow-sm">
+            <div>
+                <h2 class="text-xl font-semibold">@ViewData["Title"]</h2>
+                <p>This account has been locked out, please try again later.</p>
+            </div>
+        </div>
+    </div>
 </header>

--- a/src/tacos.mvc/Views/Account/Login.cshtml
+++ b/src/tacos.mvc/Views/Account/Login.cshtml
@@ -8,34 +8,36 @@
 @{
     ViewData["Title"] = "Log in";
 }
-<div class="col">
-<h2>Choose how you would like to log in</h2>
+<div class="mx-auto max-w-xl px-4 py-10">
+    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
+        <div class="card-body space-y-4">
+            <h2 class="card-title text-2xl">Choose how you would like to log in</h2>
 
-        @{
-            var loginProviders = (await SignInManager.GetExternalAuthenticationSchemesAsync()).ToList();
-            if (loginProviders.Count == 0)
-            {
-                <div>
-                    <p>
-                        There are no external authentication services configured. See <a href="https://go.microsoft.com/fwlink/?LinkID=532715">this article</a>
-                        for details on setting up this ASP.NET application to support logging in via external services.
-                    </p>
-                </div>
-            }
-            else
-            {
-                <form asp-action="ExternalLogin" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
+            @{
+                var loginProviders = (await SignInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+                if (loginProviders.Count == 0)
+                {
                     <div>
                         <p>
-                            @foreach (var provider in loginProviders)
-                            {
-                                <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.Name</button>
-                            }
+                            There are no external authentication services configured. See <a href="https://go.microsoft.com/fwlink/?LinkID=532715">this article</a>
+                            for details on setting up this ASP.NET application to support logging in via external services.
                         </p>
                     </div>
-                </form>
+                }
+                else
+                {
+                    <form asp-action="ExternalLogin" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post">
+                        <div class="flex flex-wrap gap-3">
+                            @foreach (var provider in loginProviders)
+                            {
+                                <button type="submit" class="tacos-btn tacos-btn--primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.Name</button>
+                            }
+                        </div>
+                    </form>
+                }
             }
-        }
+        </div>
+    </div>
 </div>
 
 @section Scripts {

--- a/src/tacos.mvc/Views/Account/LoginWith2fa.cshtml
+++ b/src/tacos.mvc/Views/Account/LoginWith2fa.cshtml
@@ -4,37 +4,36 @@
     ViewData["Title"] = "Two-factor authentication";
 }
 
-<h2>@ViewData["Title"]</h2>
-<hr />
-<p>Your login is protected with an authenticator app. Enter your authenticator code below.</p>
-<div class="row">
-    <div class="col-md-4">
-        <form method="post" asp-route-returnUrl="@ViewData["ReturnUrl"]">
-            <input asp-for="RememberMe" type="hidden" />
-            <div asp-validation-summary="All" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="TwoFactorCode"></label>
-                <input asp-for="TwoFactorCode" class="form-control" autocomplete="off" />
-                <span asp-validation-for="TwoFactorCode" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <div class="checkbox">
-                    <label asp-for="RememberMachine">
-                        <input asp-for="RememberMachine" />
-                        @Html.DisplayNameFor(m => m.RememberMachine)
-                    </label>
+<div class="mx-auto max-w-xl px-4 py-10">
+    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
+        <div class="card-body space-y-4">
+            <h2 class="card-title text-2xl">@ViewData["Title"]</h2>
+            <p>Your login is protected with an authenticator app. Enter your authenticator code below.</p>
+            <form class="space-y-4" method="post" asp-route-returnUrl="@ViewData["ReturnUrl"]">
+                <input asp-for="RememberMe" type="hidden" />
+                <div asp-validation-summary="All" class="tacos-text-danger text-sm"></div>
+                <div class="tacos-form-field">
+                    <label asp-for="TwoFactorCode" class="block font-semibold"></label>
+                    <input asp-for="TwoFactorCode" class="tacos-input" autocomplete="off" />
+                    <span asp-validation-for="TwoFactorCode" class="block pt-1 text-sm tacos-text-danger"></span>
                 </div>
-            </div>
-            <div class="form-group">
-                <button type="submit" class="btn btn-default">Log in</button>
-            </div>
-        </form>
+                <label class="flex items-center gap-3" asp-for="RememberMachine">
+                    <input asp-for="RememberMachine" class="checkbox checkbox-sm rounded-none" />
+                    <span>@Html.DisplayNameFor(m => m.RememberMachine)</span>
+                </label>
+                <div>
+                    <button type="submit" class="tacos-btn tacos-btn--primary">Log in</button>
+                </div>
+            </form>
+        </div>
     </div>
 </div>
-<p>
-    Don't have access to your authenticator device? You can 
-    <a asp-action="LoginWithRecoveryCode" asp-route-returnUrl="@ViewData["ReturnUrl"]">log in with a recovery code</a>.
-</p>
+<div class="mx-auto max-w-xl px-4 pb-10">
+    <p>
+        Don't have access to your authenticator device? You can
+        <a asp-action="LoginWithRecoveryCode" asp-route-returnUrl="@ViewData["ReturnUrl"]">log in with a recovery code</a>.
+    </p>
+</div>
 
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")

--- a/src/tacos.mvc/Views/Account/LoginWithRecoveryCode.cshtml
+++ b/src/tacos.mvc/Views/Account/LoginWithRecoveryCode.cshtml
@@ -4,23 +4,24 @@
     ViewData["Title"] = "Recovery code verification";
 }
 
-<h2>@ViewData["Title"]</h2>
-<hr />
-<p>
-    You have requested to login with a recovery code. This login will not be remembered until you provide
-    an authenticator app code at login or disable 2FA and login again.
-</p>
-<div class="row">
-    <div class="col-md-4">
-        <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="RecoveryCode"></label>
-                <input asp-for="RecoveryCode" class="form-control" autocomplete="off" />
-                <span asp-validation-for="RecoveryCode" class="text-danger"></span>
-            </div>
-            <button type="submit" class="btn btn-default">Log in</button>
-        </form>
+<div class="mx-auto max-w-xl px-4 py-10">
+    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
+        <div class="card-body space-y-4">
+            <h2 class="card-title text-2xl">@ViewData["Title"]</h2>
+            <p>
+                You have requested to login with a recovery code. This login will not be remembered until you provide
+                an authenticator app code at login or disable 2FA and login again.
+            </p>
+            <form class="space-y-4" method="post">
+                <div asp-validation-summary="All" class="tacos-text-danger text-sm"></div>
+                <div class="tacos-form-field">
+                    <label asp-for="RecoveryCode" class="block font-semibold"></label>
+                    <input asp-for="RecoveryCode" class="tacos-input" autocomplete="off" />
+                    <span asp-validation-for="RecoveryCode" class="block pt-1 text-sm tacos-text-danger"></span>
+                </div>
+                <button type="submit" class="tacos-btn tacos-btn--primary">Log in</button>
+            </form>
+        </div>
     </div>
 </div>
 

--- a/src/tacos.mvc/Views/Approval/Index.cshtml
+++ b/src/tacos.mvc/Views/Approval/Index.cshtml
@@ -45,12 +45,14 @@
                         {
                             <form class="form-inline" asp-action="Edit" asp-route-id="@request.Id" method="POST">
                                 <input type="hidden" name="approved" value="true" />
-                                <button type="submit" class="btn btn-primary mb-2 approval-form-submit" data-toggle="modal" data-target="#ApprovalModal">
+                                <button type="submit" class="btn btn-primary mb-2 approval-form-submit" onclick="document.getElementById('approvalModal').showModal()">
                                     <span class="approval-form-submit-text">Approve</span>
                                     <span class="approval-form-submit-loading-icon" style="display: none;"><i class="fas fa-circle-notch fa-spin"></i></span>
                                 </button>
                             </form>
-                            <button class="btn btn-primary mb-2" data-toggle="modal" data-target="#denialModal">Deny</button>
+                            <button type="button" class="btn btn-primary mb-2" data-denial-dialog-trigger="true" onclick="document.getElementById('denialModal').showModal()">
+                                Deny
+                            </button>
                         }
                     </td>
                 </tr>
@@ -69,63 +71,63 @@
     </table>
 </div>
 
-<form id="denialForm" asp-action="Edit" asp-route-id="0" method="post">
-    <input type="hidden" name="approved" value="false" />
-
-    <div class="modal fade" id="denialModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="exampleModalLabel">Deny Exception?</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+<dialog id="denialModal" class="modal modal-top tacos-dialog" aria-labelledby="denialModalTitle">
+    <div class="modal-box tacos-modal__content" role="document">
+        <form id="denialForm" asp-action="Edit" asp-route-id="0" method="post">
+            <input type="hidden" name="approved" value="false" />
+            <div class="tacos-modal__header">
+                <h5 class="tacos-modal__title" id="denialModalTitle">Deny Exception?</h5>
+                <button type="button" class="tacos-modal__close" aria-label="Close" onclick="this.closest('dialog').close()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="tacos-modal__body">
+                <div class="tacos-form-field">
+                    <select id="denialFormSelect" class="tacos-select" name="comment" autofocus>
+                        <option value="">Please indicate reason for denial...</option>
+                        <option value="Exception doesn’t meet criteria">Exception doesn’t meet criteria.</option>
+                        <option value="Please review/reclassify course type.">Please review/reclassify course type.</option>
+                        <option value="Other">Other:</option>
+                    </select>
                 </div>
-                <div class="modal-body">
-                    <div class="form-group">
-                        <select id="denialFormSelect" class="form-control" name="comment">
-                            <option value="">Please indicate reason for denial...</option>
-                            <option value="Exception doesn’t meet criteria">Exception doesn’t meet criteria.</option>
-                            <option value="Please review/reclassify course type.">Please review/reclassify course type.</option>
-                            <option value="Other">Other:</option>
-                        </select>
-                    </div>
-                    <div id="denialFormCommentContainer" class="form-group" style="display:none;">
-                        <textarea id="denialFormComment" class="form-control" name="commentOther" placeholder="Comment on denial..."></textarea>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-primary deny-form-submit">
-                        <span class="deny-form-submit-text">Deny Exception</span>
-                        <span class="deny-form-submit-loading-icon" style="display: none;"><i class="fas fa-circle-notch fa-spin"></i></span>
-                    </button>
+                <div id="denialFormCommentContainer" class="tacos-form-field" style="display:none;">
+                    <textarea id="denialFormComment" class="tacos-textarea" name="commentOther" placeholder="Comment on denial..."></textarea>
                 </div>
             </div>
-        </div>
+            <div class="tacos-modal__footer">
+                <button type="button" class="tacos-btn tacos-btn--secondary" onclick="this.closest('dialog').close()">Cancel</button>
+                <button type="submit" class="tacos-btn tacos-btn--primary deny-form-submit">
+                    <span class="deny-form-submit-text">Deny Exception</span>
+                    <span class="deny-form-submit-loading-icon" style="display: none;"><i class="fas fa-circle-notch fa-spin"></i></span>
+                </button>
+            </div>
+        </form>
     </div>
+    <form method="dialog" class="modal-backdrop">
+        <button aria-label="Close dialog">close</button>
+    </form>
+</dialog>
 
-</form>
-
-<!-- ApprovelModal -->
-<div class="modal fade" id="ApprovalModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">
-        <i class=" mr-3 fas fa-spinner fa-pulse fa-lg"></i>
-            <span>Approving...</span>
+<!-- ApprovalModal -->
+<dialog id="approvalModal" class="modal modal-middle tacos-dialog" aria-labelledby="approvalModalTitle">
+  <div class="modal-box tacos-modal__content" role="document">
+      <div class="tacos-modal__header">
+        <h5 class="tacos-modal__title" id="approvalModalTitle">
+          <i class="fas fa-spinner fa-pulse fa-lg tacos-inline-icon-start"></i>
+          <span>Approving...</span>
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <button type="button" class="tacos-modal__close" aria-label="Close" onclick="this.closest('dialog').close()">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body d-flex justify-content-center taco-animation-container">
+      <div class="tacos-modal__body taco-animation-container tacos-modal-body-centered">
         <img class="w-75" src="tacoAnimation.gif" alt="taco animation gif"/>
       </div>
-    </div>
   </div>
-</div>
+  <form method="dialog" class="modal-backdrop">
+      <button aria-label="Close dialog">close</button>
+  </form>
+</dialog>
 
 @section scripts {
     <script>
@@ -141,10 +143,7 @@
                     }
                 ],
                 "fixedHeader": true,
-                "dom":
-                    "<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6 d-flex justify-content-end align-items-baseline'fB>>" +
-                        "<'row'<'col-sm-12'tr>>" +
-                        "<'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7'p>>",
+                "dom": window.TacosDataTables.dom.withButtons,
                 "buttons": [
                     "excel"
                 ]
@@ -152,19 +151,34 @@
         });
 
         var editUrl = '@Url.Action("Edit", new {id = "00000"})';
+        var denialModal = document.getElementById('denialModal');
+        var denialForm = document.getElementById('denialForm');
+        var denialFormSelect = document.getElementById('denialFormSelect');
+        var denialFormComment = document.getElementById('denialFormComment');
+        var denialFormCommentContainer = document.getElementById('denialFormCommentContainer');
+        var denyButtons = document.querySelectorAll("[data-denial-dialog-trigger='true']");
 
-        $('#denialModal').on('show.bs.modal',
-            function(e) {
-                var trigger = $(e.relatedTarget);
-                var id = trigger.parents('tr').data('id');
-                var url = editUrl.replace('00000', id);
-
-                // reset form
-                $('#denialFormComment').val('');
-
-                // update url with id
-                $('#denialForm').attr('action', url);
+        if (denialModal && denialForm && denialFormSelect && denialFormComment && denialFormCommentContainer) {
+            denialModal.addEventListener('close', function () {
+                denialFormCommentContainer.style.display = 'none';
             });
+
+            denyButtons.forEach(function (button) {
+                button.addEventListener('click', function (event) {
+                    var trigger = event.currentTarget;
+                    var row = trigger ? trigger.closest('tr') : null;
+                    var id = row ? row.getAttribute('data-id') : null;
+
+                    denialFormSelect.value = '';
+                    denialFormComment.value = '';
+                    denialFormCommentContainer.style.display = 'none';
+
+                    if (id) {
+                        denialForm.setAttribute('action', editUrl.replace('00000', id));
+                    }
+                });
+            });
+        }
 
         $('.approval-form-submit').click(function () {
             // TODO: figure out a better way to disable after click, since this blocks submit
@@ -183,6 +197,15 @@
             $(this).find('.deny-form-submit-text').hide();
             $(this).find('.deny-form-submit-loading-icon').show();
         });
+
+        var approvalModal = document.getElementById('approvalModal');
+
+        if (approvalModal) {
+            approvalModal.addEventListener('close', function () {
+                $('.approval-form-submit-text').show();
+                $('.approval-form-submit-loading-icon').hide();
+            });
+        }
 
         // manage dropdown with extra comments
         $('#denialFormSelect').change(function () {

--- a/src/tacos.mvc/Views/Approval/Index.cshtml
+++ b/src/tacos.mvc/Views/Approval/Index.cshtml
@@ -1,9 +1,9 @@
 @using tacos.core.Resources
 @model tacos.core.Data.Request[]
 
-<div class="mx-auto max-w-screen-2xl px-4 py-6">
-    <div class="overflow-x-auto">
-        <table class="table w-full" id="requestTable">
+<div class="tacos-page-shell tacos-page-shell--full">
+    <div>
+        <table class="table tacos-page-table w-full" id="requestTable">
             <thead>
                 <tr>
                     <th>Submission</th>
@@ -62,7 +62,7 @@
                 }
             </tbody>
             <tfoot>
-                <tr class="bg-base-200">
+                <tr class="tacos-page-table__summary tacos-page-table__summary--info">
                     <td colspan="12"></td>
                     <td>Total:</td>
                     <td>
@@ -75,8 +75,8 @@
     </div>
 </div>
 
-<dialog id="denialModal" class="modal modal-top tacos-dialog" aria-labelledby="denialModalTitle">
-    <div class="modal-box tacos-modal__content" role="document">
+<dialog id="denialModal" class="tacos-dialog tacos-dialog--top" aria-labelledby="denialModalTitle">
+    <div class="tacos-dialog__panel tacos-modal__content" role="document">
         <form id="denialForm" asp-action="Edit" asp-route-id="0" method="post">
             <input type="hidden" name="approved" value="false" />
             <div class="tacos-modal__header">
@@ -107,14 +107,14 @@
             </div>
         </form>
     </div>
-    <form method="dialog" class="modal-backdrop">
+    <form method="dialog" class="tacos-dialog__backdrop">
         <button aria-label="Close dialog">close</button>
     </form>
 </dialog>
 
 <!-- ApprovalModal -->
-<dialog id="approvalModal" class="modal modal-middle tacos-dialog" aria-labelledby="approvalModalTitle">
-  <div class="modal-box tacos-modal__content" role="document">
+<dialog id="approvalModal" class="tacos-dialog tacos-dialog--middle" aria-labelledby="approvalModalTitle">
+  <div class="tacos-dialog__panel tacos-modal__content" role="document">
       <div class="tacos-modal__header">
         <h5 class="tacos-modal__title" id="approvalModalTitle">
           <i class="fas fa-spinner fa-pulse fa-lg tacos-inline-icon-start"></i>
@@ -128,7 +128,7 @@
         <img class="w-3/4 max-w-xs" src="tacoAnimation.gif" alt="taco animation gif"/>
       </div>
   </div>
-  <form method="dialog" class="modal-backdrop">
+  <form method="dialog" class="tacos-dialog__backdrop">
       <button aria-label="Close dialog">close</button>
   </form>
 </dialog>

--- a/src/tacos.mvc/Views/Approval/Index.cshtml
+++ b/src/tacos.mvc/Views/Approval/Index.cshtml
@@ -1,74 +1,78 @@
 @using tacos.core.Resources
 @model tacos.core.Data.Request[]
 
-<div class="container-fluid py-4">
-    <table class="table table-bordered" id="requestTable">
-        <thead>
-            <tr>
-                <th>Submission</th>
-                <th>Department</th>
-                <th>Submitter</th>
-                <th>Date</th>
-                <th>Course</th>
-                <th>Course Type</th>
-                <th>Average Sections</th>
-                <th>Average Enrollment</th>
-                <th>Request Type</th>
-                <th>Exception Reason</th>
-                <th>Exception TA % per course</th>
-                <th>Exception Annual Count</th>
-                <th>Approved TA % per course</th>
-                <th>Approved Annualized TA FTE</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var request in Model)
-            {
-                <tr data-id="@request.Id">
-                    <td>@request.Id</td>
-                    <td>@request.Department.Code</td>
-                    <td>@request.UpdatedBy</td>
-                    <td>@request.UpdatedOn.ToLocalTime().ToShortDateString()</td>
-                    <td>@request.CourseNumber</td>
-                    <td>@CourseInfo.Types[request.CourseType]</td>
-                    <td>@request.Course.AverageSectionsPerCourse</td>
-                    <td>@request.Course.AverageEnrollment.ToString("0.##")</td>
-                    <td>@CourseInfo.Requests[request.RequestType]</td>
-                    <td>@request.ExceptionReason</td>
-                    <td>@(request.Exception ? request.ExceptionTotal.ToString("f3") : "")</td>
-                    <td>@(request.Exception ? request.ExceptionAnnualCount.ToString("f3"): "")</td>
-                    <td>@request.ApprovedTotal.ToString("f3")</td>
-                    <td>@request.ApprovedAnnualizedTotal.ToString("f3")</td>
-                    <td>
-                        @if (!request.Approved.HasValue)
-                        {
-                            <form class="form-inline" asp-action="Edit" asp-route-id="@request.Id" method="POST">
-                                <input type="hidden" name="approved" value="true" />
-                                <button type="submit" class="btn btn-primary mb-2 approval-form-submit" onclick="document.getElementById('approvalModal').showModal()">
-                                    <span class="approval-form-submit-text">Approve</span>
-                                    <span class="approval-form-submit-loading-icon" style="display: none;"><i class="fas fa-circle-notch fa-spin"></i></span>
-                                </button>
-                            </form>
-                            <button type="button" class="btn btn-primary mb-2" data-denial-dialog-trigger="true" onclick="document.getElementById('denialModal').showModal()">
-                                Deny
-                            </button>
-                        }
-                    </td>
+<div class="mx-auto max-w-screen-2xl px-4 py-6">
+    <div class="overflow-x-auto">
+        <table class="table w-full" id="requestTable">
+            <thead>
+                <tr>
+                    <th>Submission</th>
+                    <th>Department</th>
+                    <th>Submitter</th>
+                    <th>Date</th>
+                    <th>Course</th>
+                    <th>Course Type</th>
+                    <th>Average Sections</th>
+                    <th>Average Enrollment</th>
+                    <th>Request Type</th>
+                    <th>Exception Reason</th>
+                    <th>Exception TA % per course</th>
+                    <th>Exception Annual Count</th>
+                    <th>Approved TA % per course</th>
+                    <th>Approved Annualized TA FTE</th>
+                    <th></th>
                 </tr>
-            }
-        </tbody>
-        <tfoot>
-            <tr class="table-info">
-                <td colspan="12"></td>
-                <td>Total:</td>
-                <td>
-                    @Model.Sum(r => r.ApprovedAnnualizedTotal).ToString("f3")
-                </td>
-                <td>&nbsp;</td>
-            </tr>
-        </tfoot>
-    </table>
+            </thead>
+            <tbody>
+                @foreach (var request in Model)
+                {
+                    <tr data-id="@request.Id">
+                        <td>@request.Id</td>
+                        <td>@request.Department.Code</td>
+                        <td>@request.UpdatedBy</td>
+                        <td>@request.UpdatedOn.ToLocalTime().ToShortDateString()</td>
+                        <td>@request.CourseNumber</td>
+                        <td>@CourseInfo.Types[request.CourseType]</td>
+                        <td>@request.Course.AverageSectionsPerCourse</td>
+                        <td>@request.Course.AverageEnrollment.ToString("0.##")</td>
+                        <td>@CourseInfo.Requests[request.RequestType]</td>
+                        <td>@request.ExceptionReason</td>
+                        <td>@(request.Exception ? request.ExceptionTotal.ToString("f3") : "")</td>
+                        <td>@(request.Exception ? request.ExceptionAnnualCount.ToString("f3"): "")</td>
+                        <td>@request.ApprovedTotal.ToString("f3")</td>
+                        <td>@request.ApprovedAnnualizedTotal.ToString("f3")</td>
+                        <td>
+                            @if (!request.Approved.HasValue)
+                            {
+                                <div class="flex flex-col items-start gap-2">
+                                    <form asp-action="Edit" asp-route-id="@request.Id" method="POST">
+                                        <input type="hidden" name="approved" value="true" />
+                                        <button type="submit" class="tacos-btn tacos-btn--primary approval-form-submit" onclick="document.getElementById('approvalModal').showModal()">
+                                            <span class="approval-form-submit-text">Approve</span>
+                                            <span class="approval-form-submit-loading-icon" style="display: none;"><i class="fas fa-circle-notch fa-spin"></i></span>
+                                        </button>
+                                    </form>
+                                    <button type="button" class="tacos-btn tacos-btn--primary" data-denial-dialog-trigger="true" onclick="document.getElementById('denialModal').showModal()">
+                                        Deny
+                                    </button>
+                                </div>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+            <tfoot>
+                <tr class="bg-base-200">
+                    <td colspan="12"></td>
+                    <td>Total:</td>
+                    <td>
+                        @Model.Sum(r => r.ApprovedAnnualizedTotal).ToString("f3")
+                    </td>
+                    <td>&nbsp;</td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
 </div>
 
 <dialog id="denialModal" class="modal modal-top tacos-dialog" aria-labelledby="denialModalTitle">
@@ -121,7 +125,7 @@
         </button>
       </div>
       <div class="tacos-modal__body taco-animation-container tacos-modal-body-centered">
-        <img class="w-75" src="tacoAnimation.gif" alt="taco animation gif"/>
+        <img class="w-3/4 max-w-xs" src="tacoAnimation.gif" alt="taco animation gif"/>
       </div>
   </div>
   <form method="dialog" class="modal-backdrop">

--- a/src/tacos.mvc/Views/Courses/Details.cshtml
+++ b/src/tacos.mvc/Views/Courses/Details.cshtml
@@ -6,7 +6,7 @@
 }
 
 
-<div class="container">
+<div class="mx-auto max-w-6xl px-4 py-6">
     <h3>Course Description Information: @Model.Course.Number</h3>
 
     <dl>

--- a/src/tacos.mvc/Views/Courses/Index.cshtml
+++ b/src/tacos.mvc/Views/Courses/Index.cshtml
@@ -1,36 +1,37 @@
 @model IList<tacos.core.Data.Course>
 
-<div class="container py-4">
-    <table id="coursesTable" class="table table-bordered">
-        <thead>
-            <tr>
-                <th>Number</th>
-                <th>Name</th>
-                <th>Average Enrollment</th>
-                <th>Average Sections</th>
-                <th>Times Offered / Year</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-        @foreach (var course in Model)
-        {
-            <tr>
-                <td>@course.Number</td>
-                <td>@course.Name</td>
-                <td>@course.AverageEnrollment</td>
-                <td>@course.AverageSectionsPerCourse</td>
-                <td>@course.TimesOfferedPerYear</td>
-                <td>
-                    <a class="btn btn-primary" asp-controller="Courses" asp-action="Details" asp-route-id="@course.Number">
-                        <i class="fas fa-info mr-2"></i> Details
-                    </a>
-                </td>
-            </tr>
-        }
-        </tbody>
-    </table>
-
+<div class="mx-auto max-w-screen-xl px-4 py-6">
+    <div class="overflow-x-auto">
+        <table id="coursesTable" class="table w-full">
+            <thead>
+                <tr>
+                    <th>Number</th>
+                    <th>Name</th>
+                    <th>Average Enrollment</th>
+                    <th>Average Sections</th>
+                    <th>Times Offered / Year</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var course in Model)
+            {
+                <tr>
+                    <td>@course.Number</td>
+                    <td>@course.Name</td>
+                    <td>@course.AverageEnrollment</td>
+                    <td>@course.AverageSectionsPerCourse</td>
+                    <td>@course.TimesOfferedPerYear</td>
+                    <td>
+                        <a class="tacos-btn tacos-btn--primary" asp-controller="Courses" asp-action="Details" asp-route-id="@course.Number">
+                            <i class="fas fa-info tacos-inline-icon-start"></i> Details
+                        </a>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
 </div>
 
 @section scripts

--- a/src/tacos.mvc/Views/Courses/Index.cshtml
+++ b/src/tacos.mvc/Views/Courses/Index.cshtml
@@ -1,8 +1,8 @@
 @model IList<tacos.core.Data.Course>
 
-<div class="mx-auto max-w-screen-xl px-4 py-6">
-    <div class="overflow-x-auto">
-        <table id="coursesTable" class="table w-full">
+<div class="tacos-page-shell">
+    <div>
+        <table id="coursesTable" class="table tacos-page-table w-full">
             <thead>
                 <tr>
                     <th>Number</th>

--- a/src/tacos.mvc/Views/Courses/Index.cshtml
+++ b/src/tacos.mvc/Views/Courses/Index.cshtml
@@ -43,7 +43,8 @@
                         "targets": [-1],
                         "sortable": false
                     }],
-                "order": [[1, "desc"]]
+                "order": [[1, "desc"]],
+                "dom": window.TacosDataTables.dom.standard
             });
         });
     </script>

--- a/src/tacos.mvc/Views/Home/Index.cshtml
+++ b/src/tacos.mvc/Views/Home/Index.cshtml
@@ -2,41 +2,41 @@
     ViewData["Title"] = "Home Page";
 }
 
-<section class="jumbotron jumbotron-fluid">
-    <div class="container">
-        <h1 class="jumbotron-heading text-center">TA Calculation App</h1>
-        <p class="lead text-center">CA&ES TA funding request system</p>
-        <h4>
-            <a href="https://tacos.ucdavis.edu/CAES-TA-Guidelines%202018-23.pdf">
-                CA&ES Criteria for TA Funding
-            </a>
-        </h4>
-        <p>
-        Criteria for central TA Funding are updated every 3 years by a committee of CA&ES Faculty.
-        </p>
-        <p>
-        Requests for additional TA or Reader support for courses with unusually special circumstances will be considered using the exception request process.
-        </p>
-        <h4>
-            Annual Timeline
-        </h4>
-        <ul class="list-unstyled">
-            <li>
-                March – Annual data refresh
-            </li>
-            <li>
-                April – Call for departments to begin reviewing and entering annual TA submissions 
-            </li>
-            <li>
-                August – Deadline for departments to review and finalize annual TA submissions
-            </li>
-            <li>
-                September-October – Dean’s Office plans to allocate annual TA funding to departments
-            </li>
-        </ul>
-        <p>Ad-hoc exception requests for changed circumstances (example: adding a new section to reduce waitlist) may be submitted throughout the year and funding will be allocated upon approval.</p>
-        <p class="text-center">
-            <a asp-controller="Requests" asp-action="index" class="btn btn-secondary my-2">View My Existing Requests</a>
-        </p>
+<section class="tacos-home-panel">
+    <div class="tacos-home-panel__content">
+        <div class="tacos-home-panel__intro">
+            <h1 class="tacos-home-panel__title">TA Calculation App</h1>
+            <p class="tacos-home-panel__subtitle">CA&amp;ES TA funding request system</p>
+        </div>
+
+        <div class="tacos-home-panel__body">
+            <h4 class="tacos-home-panel__section-title tacos-home-panel__section-title--link">
+                <a href="https://tacos.ucdavis.edu/CAES-TA-Guidelines%202018-23.pdf">
+                    CA&amp;ES Criteria for TA Funding
+                </a>
+            </h4>
+            <p>
+                Criteria for central TA Funding are updated every 3 years by a committee of CA&amp;ES Faculty.
+            </p>
+            <p>
+                Requests for additional TA or Reader support for courses with unusually special circumstances will be considered using the exception request process.
+            </p>
+
+            <h4 class="tacos-home-panel__section-title">Annual Timeline</h4>
+            <ul class="tacos-home-panel__timeline">
+                <li>March – Annual data refresh</li>
+                <li>April – Call for departments to begin reviewing and entering annual TA submissions</li>
+                <li>August – Deadline for departments to review and finalize annual TA submissions</li>
+                <li>September-October – Dean’s Office plans to allocate annual TA funding to departments</li>
+            </ul>
+
+            <p>
+                Ad-hoc exception requests for changed circumstances (example: adding a new section to reduce waitlist) may be submitted throughout the year and funding will be allocated upon approval.
+            </p>
+
+            <div class="tacos-home-panel__actions">
+                <a asp-controller="Requests" asp-action="index" class="tacos-btn tacos-btn--secondary">View My Existing Requests</a>
+            </div>
+        </div>
     </div>
 </section>

--- a/src/tacos.mvc/Views/Requests/Details.cshtml
+++ b/src/tacos.mvc/Views/Requests/Details.cshtml
@@ -6,7 +6,7 @@
     var history = Model.History.OrderByDescending(h => h.UpdatedOn).Skip(1);
 }
 
-<div class="container">
+<div class="mx-auto max-w-6xl space-y-8 px-4 py-6">
     <h3>Course Information</h3>
 
     <dl>
@@ -16,7 +16,7 @@
         <dt>Name</dt>
         <dd>@Model.Course.Name</dd>
 
-        <dt>Course Type <span class="text-muted">(as reported in request)</span></dt>
+        <dt>Course Type <span class="tacos-text-muted">(as reported in request)</span></dt>
         <dd>@CourseInfo.Types[Model.CourseType]</dd>
 
         <dt>Average Enrollment</dt>
@@ -81,38 +81,40 @@
 
     <h3>History of this request</h3>
     
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Course Number</th>
-                <th>Course Type</th>
-                <th>Suggested Total</th>
-                <th>Requested Total</th>
-                <th>Reason</th>
-                <th>Reviewed?</th>
-                <th>Approved?</th>
-                <th>Approval Reason</th>
-                <th>Updated On</th>
-                <th>Updated By</th>
-            </tr>
-        </thead>
-        <tbody>
-        @foreach (var h in history)
-        {
-            <tr>
-                <td>@h.CourseNumber</td>
-                <td>@CourseInfo.Types[h.CourseType]</td>
-                <td>@(h.CalculatedTotal)</td>
-                <td>@(h.Exception ? h.ExceptionTotal.ToString() : "")</td>
-                <td>@(h.Exception ? h.ExceptionReason : "")</td>
-                <td>@(h.Approved.HasValue ? "Yes" : "No")</td>
-                <td>@(h.Approved.HasValue ? (h.Approved.Value ? "Yes" : "No") : "")</td>
-                <td>@(h.Exception ? h.ApprovedComment : "")</td>
-                <td>@h.UpdatedOn.ToString("G")</td>
-                <td>@h.UpdatedBy</td>
-            </tr>
-        }
-        </tbody>
-    </table>
+    <div class="overflow-x-auto">
+        <table class="table w-full">
+            <thead>
+                <tr>
+                    <th>Course Number</th>
+                    <th>Course Type</th>
+                    <th>Suggested Total</th>
+                    <th>Requested Total</th>
+                    <th>Reason</th>
+                    <th>Reviewed?</th>
+                    <th>Approved?</th>
+                    <th>Approval Reason</th>
+                    <th>Updated On</th>
+                    <th>Updated By</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var h in history)
+            {
+                <tr>
+                    <td>@h.CourseNumber</td>
+                    <td>@CourseInfo.Types[h.CourseType]</td>
+                    <td>@(h.CalculatedTotal)</td>
+                    <td>@(h.Exception ? h.ExceptionTotal.ToString() : "")</td>
+                    <td>@(h.Exception ? h.ExceptionReason : "")</td>
+                    <td>@(h.Approved.HasValue ? "Yes" : "No")</td>
+                    <td>@(h.Approved.HasValue ? (h.Approved.Value ? "Yes" : "No") : "")</td>
+                    <td>@(h.Exception ? h.ApprovedComment : "")</td>
+                    <td>@h.UpdatedOn.ToString("G")</td>
+                    <td>@h.UpdatedBy</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
 
 </div>

--- a/src/tacos.mvc/Views/Requests/Details.cshtml
+++ b/src/tacos.mvc/Views/Requests/Details.cshtml
@@ -81,8 +81,8 @@
 
     <h3>History of this request</h3>
     
-    <div class="overflow-x-auto">
-        <table class="table w-full">
+    <div class="tacos-page-table-frame">
+        <table class="table tacos-page-table w-full">
             <thead>
                 <tr>
                     <th>Course Number</th>

--- a/src/tacos.mvc/Views/Requests/Edit.cshtml
+++ b/src/tacos.mvc/Views/Requests/Edit.cshtml
@@ -8,7 +8,7 @@
     var departments = (IList<Department>)ViewBag.Departments;
 }
 
-<div class="edit-requests container py-4">
+<div class="edit-requests px-4 py-6">
     <div id="react-app">Loading...</div>
 </div>
 

--- a/src/tacos.mvc/Views/Requests/Edit.cshtml
+++ b/src/tacos.mvc/Views/Requests/Edit.cshtml
@@ -8,7 +8,7 @@
     var departments = (IList<Department>)ViewBag.Departments;
 }
 
-<div class="edit-requests px-4 py-6">
+<div class="edit-requests px-4 pb-6">
     <div id="react-app">Loading...</div>
 </div>
 

--- a/src/tacos.mvc/Views/Requests/Empty.cshtml
+++ b/src/tacos.mvc/Views/Requests/Empty.cshtml
@@ -1,7 +1,11 @@
 @{
 }
 
-<div class="container my-4">
-    <h3>Your requests by department:</h3>
-    <span>You don't appear to belong to any departments.</span>
+<div class="mx-auto max-w-4xl px-4 py-6">
+    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
+        <div class="card-body">
+            <h3 class="card-title text-2xl">Your requests by department</h3>
+            <p>You don't appear to belong to any departments.</p>
+        </div>
+    </div>
 </div>

--- a/src/tacos.mvc/Views/Requests/Index.cshtml
+++ b/src/tacos.mvc/Views/Requests/Index.cshtml
@@ -7,7 +7,7 @@
     var departments = ViewBag.Departments as IList<Department>;
 }
 
-<div class="mx-auto max-w-screen-xl space-y-6 px-4 py-6">
+<div class="tacos-page-shell tacos-page-stack">
 
     @{
         var departmentSelectItems = departments.Select(d => new SelectListItem()
@@ -18,28 +18,28 @@
         });
     }
 
-    <div class="max-w-md space-y-2">
+    <div class="tacos-page-form-field space-y-2">
         <label class="block font-semibold" for="departmentSelect">Selected department:</label>
         <select class="tacos-select" id="departmentSelect" asp-items="departmentSelectItems"></select>
     </div>
     
-    <hr />
+    <hr class="tacos-page-divider" />
 
     <div class="space-y-3">
         <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
-                <h4>@department.Name</h4>
+                <h4 class="tacos-page-heading">@department.Name</h4>
             </div>
             <div>
                 <a class="tacos-btn tacos-btn--primary" asp-controller="Requests" asp-action="edit" asp-route-code="@department.Code" asp-route-jsAction="create">Create New Submission</a>
             </div>
         </div>
         
-        <p class="text-sm opacity-70">@Model.Count total requests. (@Model.Count(r => !r.Submitted) unsubmitted requests)</p>
+        <p class="tacos-page-meta">@Model.Count total requests. (@Model.Count(r => !r.Submitted) unsubmitted requests)</p>
     </div>
 
-    <div class="overflow-x-auto">
-        <table id="requestTable" class="table w-full">
+    <div>
+        <table id="requestTable" class="table tacos-page-table w-full">
             <thead>
                 <tr>
                     <th>Course Number</th>
@@ -63,7 +63,7 @@
                         <td data-order="@request.UpdatedOn.Ticks">
                             @request.SubmittedOn?.ToString("d")
                         </td>
-                        <td class="text-center">
+                        <td class="tacos-page-table__actions">
                             <a asp-action="Edit" asp-route-id="@request.Id" asp-route-code="@request.Department.Code" asp-route-jsAction="edit" class="tacos-btn tacos-btn--primary">
                                 <i class="fas fa-edit tacos-inline-icon-start"></i> Edit
                             </a>

--- a/src/tacos.mvc/Views/Requests/Index.cshtml
+++ b/src/tacos.mvc/Views/Requests/Index.cshtml
@@ -86,6 +86,7 @@
                 [ 10, 25, 50, -1 ],
                 [ 10, 25, 50, "All" ],
             ],
+            "dom": window.TacosDataTables.dom.standard,
             "columnDefs": [
                 {
                     "targets": [-1],

--- a/src/tacos.mvc/Views/Requests/Index.cshtml
+++ b/src/tacos.mvc/Views/Requests/Index.cshtml
@@ -83,12 +83,19 @@
             window.location.href = "/requests/?code=" + code;
         });
 
+        var defaultDom = "<'tacos-datatable-toolbar'<'tacos-datatable-toolbar__length'l><'tacos-datatable-toolbar__actions'f>>" +
+            "<'tacos-datatable-table'tr>" +
+            "<'tacos-datatable-footer'<'tacos-datatable-footer__info'i><'tacos-datatable-footer__pagination'p>>";
+        var dataTableDom = window.TacosDataTables && window.TacosDataTables.dom && window.TacosDataTables.dom.standard
+            ? window.TacosDataTables.dom.standard
+            : defaultDom;
+
         $('#requestTable').DataTable({
             "lengthMenu": [
                 [ 10, 25, 50, -1 ],
                 [ 10, 25, 50, "All" ],
             ],
-            "dom": window.TacosDataTables.dom.standard,
+            "dom": dataTableDom,
             "columnDefs": [
                 {
                     "targets": [-1],

--- a/src/tacos.mvc/Views/Requests/Index.cshtml
+++ b/src/tacos.mvc/Views/Requests/Index.cshtml
@@ -7,7 +7,7 @@
     var departments = ViewBag.Departments as IList<Department>;
 }
 
-<div class="container my-4">
+<div class="mx-auto max-w-screen-xl space-y-6 px-4 py-6">
 
     @{
         var departmentSelectItems = departments.Select(d => new SelectListItem()
@@ -18,59 +18,61 @@
         });
     }
 
-    <div class="form-group mb-4">
-        <label>Selected department:</label>
-        <select class="form-control" id="departmentSelect" asp-items="departmentSelectItems"></select>
+    <div class="max-w-md space-y-2">
+        <label class="block font-semibold" for="departmentSelect">Selected department:</label>
+        <select class="tacos-select" id="departmentSelect" asp-items="departmentSelectItems"></select>
     </div>
     
     <hr />
 
-    <div class="mb-4">
-        <div class="row">
-            <div class="col">
+    <div class="space-y-3">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
                 <h4>@department.Name</h4>
             </div>
-            <div class="col d-flex justify-content-end align-items-center">
-                <a class="btn btn-primary" asp-controller="Requests" asp-action="edit" asp-route-code="@department.Code" asp-route-jsAction="create">Create New Submission</a>
+            <div>
+                <a class="tacos-btn tacos-btn--primary" asp-controller="Requests" asp-action="edit" asp-route-code="@department.Code" asp-route-jsAction="create">Create New Submission</a>
             </div>
         </div>
         
-        <span>@Model.Count total requests. (@Model.Count(r => !r.Submitted) unsubmitted requests)</span>
+        <p class="text-sm opacity-70">@Model.Count total requests. (@Model.Count(r => !r.Submitted) unsubmitted requests)</p>
     </div>
 
-    <table id="requestTable" class="table table-bordered">
-        <thead>
-            <tr>
-                <th>Course Number</th>
-                <th>Course Type</th>
-                <th>Submitted On</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var request in Model)
-            {
+    <div class="overflow-x-auto">
+        <table id="requestTable" class="table w-full">
+            <thead>
                 <tr>
-                    <td>
-                        <a asp-action="Details" asp-route-id="@request.Id">
-                            @request.CourseNumber
-                        </a>
-                    </td>
-                    <td>
-                        @CourseInfo.Types[request.CourseType]
-                    </td>
-                    <td data-order="@request.UpdatedOn.Ticks">
-                        @request.SubmittedOn?.ToString("d")
-                    </td>
-                    <td class="text-center">
-                        <a asp-action="Edit" asp-route-id="@request.Id" asp-route-code="@request.Department.Code" asp-route-jsAction="edit" class="btn btn-primary">
-                            <i class="fas fa-edit"></i> Edit
-                        </a>
-                    </td>
+                    <th>Course Number</th>
+                    <th>Course Type</th>
+                    <th>Submitted On</th>
+                    <th></th>
                 </tr>
-            }
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+                @foreach (var request in Model)
+                {
+                    <tr>
+                        <td>
+                            <a asp-action="Details" asp-route-id="@request.Id">
+                                @request.CourseNumber
+                            </a>
+                        </td>
+                        <td>
+                            @CourseInfo.Types[request.CourseType]
+                        </td>
+                        <td data-order="@request.UpdatedOn.Ticks">
+                            @request.SubmittedOn?.ToString("d")
+                        </td>
+                        <td class="text-center">
+                            <a asp-action="Edit" asp-route-id="@request.Id" asp-route-code="@request.Department.Code" asp-route-jsAction="edit" class="tacos-btn tacos-btn--primary">
+                                <i class="fas fa-edit tacos-inline-icon-start"></i> Edit
+                            </a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
 </div>
 
 @section scripts

--- a/src/tacos.mvc/Views/Review/Index.cshtml
+++ b/src/tacos.mvc/Views/Review/Index.cshtml
@@ -1,9 +1,9 @@
 @using tacos.core.Resources
 @model tacos.core.Data.Request[]
 
-<div class="mx-auto max-w-screen-2xl px-4 py-6">
-    <div class="overflow-x-auto">
-        <table class="table w-full" id="requestTable">
+<div class="tacos-page-shell tacos-page-shell--full">
+    <div>
+        <table class="table tacos-page-table w-full" id="requestTable">
             <thead>
                 <tr>
                     <th>Department</th>
@@ -42,7 +42,7 @@
             }
             </tbody>
             <tfoot>
-            <tr class="bg-base-200">
+            <tr class="tacos-page-table__summary">
                 <td colspan="11"></td>
                 <td>Total:</td>
                 <td>

--- a/src/tacos.mvc/Views/Review/Index.cshtml
+++ b/src/tacos.mvc/Views/Review/Index.cshtml
@@ -1,55 +1,57 @@
 @using tacos.core.Resources
 @model tacos.core.Data.Request[]
 
-<div class="container-fluid my-4">
-    <table class="table table-bordered" id="requestTable">
-        <thead>
-            <tr>
-                <th>Department</th>
-                <th>Course</th>
-                <th>Submitter</th>
-                <th>Date</th>
-                <th>Course Type</th>
-                <th>Average Sections</th>
-                <th>Average Enrollment</th>
-                <th>Request Type</th>
-                <th>Exception Reason</th>
-                <th>Exception TA % per course</th>
-                <th>Exception Annual Count</th>
-                <th>Approved TA % per course</th>
-                <th>Approved Annualized TA FTE</th>
+<div class="mx-auto max-w-screen-2xl px-4 py-6">
+    <div class="overflow-x-auto">
+        <table class="table w-full" id="requestTable">
+            <thead>
+                <tr>
+                    <th>Department</th>
+                    <th>Course</th>
+                    <th>Submitter</th>
+                    <th>Date</th>
+                    <th>Course Type</th>
+                    <th>Average Sections</th>
+                    <th>Average Enrollment</th>
+                    <th>Request Type</th>
+                    <th>Exception Reason</th>
+                    <th>Exception TA % per course</th>
+                    <th>Exception Annual Count</th>
+                    <th>Approved TA % per course</th>
+                    <th>Approved Annualized TA FTE</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach(var request in Model)
+            {
+                <tr>
+                    <td>@request.Department.Code</td>
+                    <td><a asp-controller="Requests" asp-action="Details" asp-route-id="@request.Id">@request.CourseNumber</a></td>
+                    <td>@request.UpdatedBy</td>
+                    <td>@request.UpdatedOn.ToLocalTime().ToShortDateString()</td>
+                    <td>@CourseInfo.Types[request.CourseType]</td>
+                    <td>@request.Course.AverageSectionsPerCourse</td>
+                    <td>@request.Course.AverageEnrollment.ToString("0.##")</td>
+                    <td>@CourseInfo.Requests[request.RequestType]</td>
+                    <td>@(request.Exception ? request.ExceptionReason : "")</td>
+                    <td>@(request.Exception ? request.ExceptionTotal.ToString("f3") : "")</td>
+                    <td>@(request.Exception ? request.ExceptionAnnualCount.ToString("f3"): "")</td>
+                    <td>@request.ApprovedTotal.ToString("f3")</td>
+                    <td>@request.ApprovedAnnualizedTotal.ToString("f3")</td>
+                </tr>
+            }
+            </tbody>
+            <tfoot>
+            <tr class="bg-base-200">
+                <td colspan="11"></td>
+                <td>Total:</td>
+                <td>
+                    @Model.Sum(r => r.ApprovedAnnualizedTotal).ToString("f3")
+                </td>
             </tr>
-        </thead>
-        <tbody>
-        @foreach(var request in Model)
-        {
-            <tr>
-                <td>@request.Department.Code</td>
-                <td><a asp-controller="Requests" asp-action="Details" asp-route-id="@request.Id">@request.CourseNumber</a></td>
-                <td>@request.UpdatedBy</td>
-                <td>@request.UpdatedOn.ToLocalTime().ToShortDateString()</td>
-                <td>@CourseInfo.Types[request.CourseType]</td>
-                <td>@request.Course.AverageSectionsPerCourse</td>
-                <td>@request.Course.AverageEnrollment.ToString("0.##")</td>
-                <td>@CourseInfo.Requests[request.RequestType]</td>
-                <td>@(request.Exception ? request.ExceptionReason : "")</td>
-                <td>@(request.Exception ? request.ExceptionTotal.ToString("f3") : "")</td>
-                <td>@(request.Exception ? request.ExceptionAnnualCount.ToString("f3"): "")</td>
-                <td>@request.ApprovedTotal.ToString("f3")</td>
-                <td>@request.ApprovedAnnualizedTotal.ToString("f3")</td>
-            </tr>
-        }
-        </tbody>
-        <tfoot>
-        <tr class="table-info">
-            <td colspan="11"></td>
-            <td>Total:</td>
-            <td>
-                @Model.Sum(r => r.ApprovedAnnualizedTotal).ToString("f3")
-            </td>
-        </tr>
-        </tfoot>
-    </table>
+            </tfoot>
+        </table>
+    </div>
 </div>
 
 @section scripts {

--- a/src/tacos.mvc/Views/Review/Index.cshtml
+++ b/src/tacos.mvc/Views/Review/Index.cshtml
@@ -60,10 +60,7 @@
                 "info": false,
                 "order": [[2, "desc"]],
                 "fixedHeader": true,
-                "dom": 
-                    "<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6 d-flex justify-content-end align-items-baseline'fB>>" +
-                        "<'row'<'col-sm-12'tr>>" +
-                        "<'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7'p>>",
+                "dom": window.TacosDataTables.dom.withButtons,
                 "buttons": [
                     "excel"
                 ]

--- a/src/tacos.mvc/Views/Shared/Error.cshtml
+++ b/src/tacos.mvc/Views/Shared/Error.cshtml
@@ -2,20 +2,28 @@
     ViewData["Title"] = "Error";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<div class="mx-auto max-w-3xl space-y-6 px-4 py-10">
+    <div class="alert alert-error rounded-none shadow-sm">
+        <div>
+            <h1 class="text-3xl font-bold">Error.</h1>
+            <h2 class="text-xl font-semibold">An error occurred while processing your request.</h2>
+        </div>
+    </div>
 
-@if (!string.IsNullOrEmpty((string)ViewData["RequestId"]))
-{
-    <p>
-        <strong>Request ID:</strong> <code>@ViewData["RequestId"]</code>
-    </p>
-}
+    @if (!string.IsNullOrEmpty((string)ViewData["RequestId"]))
+    {
+        <p>
+            <strong>Request ID:</strong> <code>@ViewData["RequestId"]</code>
+        </p>
+    }
 
-<h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-</p>
-<p>
-    <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
-</p>
+    <div class="space-y-3">
+        <h3 class="text-xl font-semibold">Development Mode</h3>
+        <p>
+            Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
+        </p>
+        <p>
+            <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
+        </p>
+    </div>
+</div>

--- a/src/tacos.mvc/Views/Shared/_DatatablesScriptsPartial.cshtml
+++ b/src/tacos.mvc/Views/Shared/_DatatablesScriptsPartial.cshtml
@@ -1,9 +1,7 @@
 <environment names="Development">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/1.10.18/js/jquery.dataTables.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/1.10.18/js/dataTables.bootstrap4.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.4/js/dataTables.buttons.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.4/js/buttons.bootstrap4.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.4/js/buttons.html5.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/fixedheader/3.1.4/js/dataTables.fixedHeader.js"></script>
 
@@ -11,9 +9,21 @@
 <environment names="Staging,Production">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/2.5.0/jszip.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/1.10.18/js/jquery.dataTables.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/1.10.18/js/dataTables.bootstrap4.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.4/js/dataTables.buttons.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.4/js/buttons.bootstrap4.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.4/js/buttons.html5.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/fixedheader/3.1.4/js/dataTables.fixedHeader.min.js"></script>
 </environment>
+<script>
+    window.TacosDataTables = window.TacosDataTables || {
+        dom: {
+            standard:
+                "<'tacos-datatable-toolbar'<'tacos-datatable-toolbar__length'l><'tacos-datatable-toolbar__actions'f>>" +
+                "<'tacos-datatable-table'tr>" +
+                "<'tacos-datatable-footer'<'tacos-datatable-footer__info'i><'tacos-datatable-footer__pagination'p>>",
+            withButtons:
+                "<'tacos-datatable-toolbar'<'tacos-datatable-toolbar__length'l><'tacos-datatable-toolbar__actions'fB>>" +
+                "<'tacos-datatable-table'tr>" +
+                "<'tacos-datatable-footer'<'tacos-datatable-footer__info'i><'tacos-datatable-footer__pagination'p>>"
+        }
+    };
+</script>

--- a/src/tacos.mvc/Views/Shared/_DatatablesStylesPartial.cshtml
+++ b/src/tacos.mvc/Views/Shared/_DatatablesStylesPartial.cshtml
@@ -1,11 +1,11 @@
 <environment names="Development">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/dataTables.bootstrap4.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.bootstrap4.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.bootstrap4.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/jquery.dataTables.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.dataTables.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.dataTables.css"/>
 
 </environment>
 <environment names="Staging,Production">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/dataTables.bootstrap4.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.bootstrap4.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.bootstrap4.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/jquery.dataTables.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.dataTables.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.dataTables.min.css"/>
 </environment>

--- a/src/tacos.mvc/Views/Shared/_DatatablesStylesPartial.cshtml
+++ b/src/tacos.mvc/Views/Shared/_DatatablesStylesPartial.cshtml
@@ -1,11 +1,11 @@
 <environment names="Development">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/jquery.dataTables.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.dataTables.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.dataTables.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/jquery.dataTables.css" integrity="sha384-88btmYK8qOHy4Z2XuhkWZjUOHICKYe1eSDMwaDGOAy802OCu6PD6mwqY5OwnfGwp" crossorigin="anonymous"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.dataTables.css" integrity="sha384-YjM3jj0G+cISTAcQ9n2eJ2GNHBo4xzeDjrhxbKN2iwf6TpzMl/g0bHe4zd8fRBLq" crossorigin="anonymous"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.dataTables.css" integrity="sha384-lpWTxwtisXrjkL+lYRRcWjk3cPiY3l5s3UD0DSZwXn5LXmLNnNG9vM5Fv/HczT/G" crossorigin="anonymous"/>
 
 </environment>
 <environment names="Staging,Production">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/jquery.dataTables.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.dataTables.min.css"/>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.dataTables.min.css"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/jquery.dataTables.min.css" integrity="sha384-1UXhfqyOyO+W+XsGhiIFwwD3hsaHRz2XDGMle3b8bXPH5+cMsXVShDoHA3AH/y/p" crossorigin="anonymous"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.5.4/css/buttons.dataTables.min.css" integrity="sha384-H3tFNLWHo7pRKl45l3g6nUsNwtq+tjdhXKXWYbuuGGdcW+46p3nuQsPCTuQHZNzv" crossorigin="anonymous"/>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.4/css/fixedHeader.dataTables.min.css" integrity="sha384-cY1uzCzO44ePFj7SuycPyEeX5wDoFcSo7mwWCZiknLCspHpPgkxNaj3LOmZxb0Nm" crossorigin="anonymous"/>
 </environment>

--- a/src/tacos.mvc/Views/Shared/_Layout.cshtml
+++ b/src/tacos.mvc/Views/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,12 +7,10 @@
     <base href="~/" />
 
     <environment names="Development">
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.css" />
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.6/css/all.css" />
         <link rel="stylesheet" href="https://ucdcdn.azureedge.net/public/ucdavis.1.0.7.css" />
     </environment>
     <environment names="Staging,Production">
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.6/css/all.css">
         <link rel="stylesheet" href="https://ucdcdn.azureedge.net/public/ucdavis.1.0.7.css" />
     </environment>
@@ -24,64 +22,69 @@
     @RenderSection("styles", required: false)
 </head>
 <body>
-    <nav class="navbar navbar-default navbar-expand-lg">
-        <div class="navbar-banner">
-            <a class="navbar-brand" asp-action="index" asp-controller="home">
+    <nav class="tacos-site-nav">
+        <div class="tacos-site-nav__banner">
+            <a class="tacos-site-nav__brand" asp-action="index" asp-controller="home">
                 <img src="logo.svg" alt="TA Calculated Outcomes System" />
             </a>
-            <button class="navbar-toggler" type="button" data-tacos-collapse-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
+            <button class="tacos-site-nav__toggle" type="button" data-tacos-collapse-target="#siteNavigation" aria-controls="siteNavigation" aria-expanded="false" aria-label="Toggle navigation">
+                <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
         </div>
 
-
-        <div class="navbar-row collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item @(ViewContext.RouteData.Values["Controller"].ToString() == "submission" ? "active" : "")">
-                    <a class="nav-link" asp-controller="Requests" asp-action="index">Requests</a>
+        <div class="tacos-site-nav__panel" id="siteNavigation">
+            <div class="tacos-site-nav__inner">
+                <ul class="menu menu-vertical gap-1 p-0 lg:menu-horizontal tacos-site-nav__links">
+                <li>
+                    <a class="tacos-site-nav__link @(ViewContext.RouteData.Values["Controller"]?.ToString() == "Requests" ? "tacos-site-nav__link--active" : "")" asp-controller="Requests" asp-action="index">Requests</a>
                 </li>
-                <li class="nav-item @(ViewContext.RouteData.Values["Controller"].ToString() == "submission" ? "active" : "")">
-                    <a class="nav-link" asp-controller="Courses" asp-action="index">Courses</a>
+                <li>
+                    <a class="tacos-site-nav__link @(ViewContext.RouteData.Values["Controller"]?.ToString() == "Courses" ? "tacos-site-nav__link--active" : "")" asp-controller="Courses" asp-action="index">Courses</a>
                 </li>
                 @if (User.IsInRole("Reviewer"))
                 {
-                    <li class="nav-item @(ViewContext.RouteData.Values["Action"].ToString() == "review" ? "active" : "")">
-                        <a class="nav-link" asp-controller="review" asp-action="index">Review</a>
+                    <li>
+                        <a class="tacos-site-nav__link @(ViewContext.RouteData.Values["Controller"]?.ToString() == "Review" ? "tacos-site-nav__link--active" : "")" asp-controller="review" asp-action="index">Review</a>
                     </li>
                 }
                 @if (User.IsInRole("Admin"))
                 {
-                    <li class="nav-item @(ViewContext.RouteData.Values["Action"].ToString() == "admin" ? "active" : "")">
-                        <a class="nav-link" asp-controller="Approval" asp-action="index">Approvals</a>
+                    <li>
+                        <a class="tacos-site-nav__link @(ViewContext.RouteData.Values["Controller"]?.ToString() == "Approval" ? "tacos-site-nav__link--active" : "")" asp-controller="Approval" asp-action="index">Approvals</a>
                     </li>
-                    <li class="nav-item @(ViewContext.RouteData.Values["Action"].ToString() == "system" ? "active" : "")">
-                        <a class="nav-link" asp-controller="system" asp-action="Index">Users</a>
+                    <li>
+                        <a class="tacos-site-nav__link @(ViewContext.RouteData.Values["Controller"]?.ToString() == "System" ? "tacos-site-nav__link--active" : "")" asp-controller="system" asp-action="Index">Users</a>
                     </li>
                 }
-            </ul>
-            <form class="form-inline my-2 my-lg-0 flex-shrink-0">
-                @await Html.PartialAsync("_LoginPartial")
-            </form>
+                </ul>
+                <div class="tacos-site-nav__user">
+                    @await Html.PartialAsync("_LoginPartial")
+                </div>
+            </div>
         </div>
     </nav>
         
     @if (!string.IsNullOrWhiteSpace(TempData["ErrorMessage"] as string))
     {
-        <div class="alert alert-danger">
-            <button type="button" class="close tacos-alert__close" data-tacos-dismiss="alert" aria-label="Dismiss error message">×</button>
-            @TempData["ErrorMessage"]
+        <div class="mx-auto max-w-screen-2xl px-4 pt-4">
+            <div class="alert alert-error rounded-none shadow-sm">
+                <span>@TempData["ErrorMessage"]</span>
+                <button type="button" class="btn btn-ghost btn-square btn-sm ml-auto" data-tacos-dismiss="alert" aria-label="Dismiss error message">×</button>
+            </div>
         </div>
     }
 
     @if (!string.IsNullOrWhiteSpace(TempData["Message"] as string))
     {
-        <div class="alert alert-info">
-            <button type="button" class="close tacos-alert__close" data-tacos-dismiss="alert" aria-label="Dismiss message">×</button>
-            @TempData["Message"]
+        <div class="mx-auto max-w-screen-2xl px-4 pt-4">
+            <div class="alert alert-info rounded-none shadow-sm">
+                <span>@TempData["Message"]</span>
+                <button type="button" class="btn btn-ghost btn-square btn-sm ml-auto" data-tacos-dismiss="alert" aria-label="Dismiss message">×</button>
+            </div>
         </div>
     }
 
-    <div class="py-4">
+    <div class="pb-6">
         @RenderBody()
     </div>
     

--- a/src/tacos.mvc/Views/Shared/_Layout.cshtml
+++ b/src/tacos.mvc/Views/Shared/_Layout.cshtml
@@ -66,7 +66,7 @@
         
     @if (!string.IsNullOrWhiteSpace(TempData["ErrorMessage"] as string))
     {
-        <div class="mx-auto max-w-screen-2xl px-4 pt-4">
+        <div class="tacos-page-shell tacos-page-shell--flash">
             <div class="alert alert-error rounded-none shadow-sm">
                 <span>@TempData["ErrorMessage"]</span>
                 <button type="button" class="btn btn-ghost btn-square btn-sm ml-auto" data-tacos-dismiss="alert" aria-label="Dismiss error message">×</button>
@@ -76,7 +76,7 @@
 
     @if (!string.IsNullOrWhiteSpace(TempData["Message"] as string))
     {
-        <div class="mx-auto max-w-screen-2xl px-4 pt-4">
+        <div class="tacos-page-shell tacos-page-shell--flash">
             <div class="alert alert-info rounded-none shadow-sm">
                 <span>@TempData["Message"]</span>
                 <button type="button" class="btn btn-ghost btn-square btn-sm ml-auto" data-tacos-dismiss="alert" aria-label="Dismiss message">×</button>

--- a/src/tacos.mvc/Views/Shared/_Layout.cshtml
+++ b/src/tacos.mvc/Views/Shared/_Layout.cshtml
@@ -29,7 +29,7 @@
             <a class="navbar-brand" asp-action="index" asp-controller="home">
                 <img src="logo.svg" alt="TA Calculated Outcomes System" />
             </a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-tacos-collapse-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
         </div>
@@ -68,7 +68,7 @@
     @if (!string.IsNullOrWhiteSpace(TempData["ErrorMessage"] as string))
     {
         <div class="alert alert-danger">
-            <button type="button" class="close" data-dismiss="alert">×</button>
+            <button type="button" class="close tacos-alert__close" data-tacos-dismiss="alert" aria-label="Dismiss error message">×</button>
             @TempData["ErrorMessage"]
         </div>
     }
@@ -76,7 +76,7 @@
     @if (!string.IsNullOrWhiteSpace(TempData["Message"] as string))
     {
         <div class="alert alert-info">
-            <button type="button" class="close" data-dismiss="alert">×</button>
+            <button type="button" class="close tacos-alert__close" data-tacos-dismiss="alert" aria-label="Dismiss message">×</button>
             @TempData["Message"]
         </div>
     }
@@ -87,23 +87,14 @@
     
     <environment names="Development">
         <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.js"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.js"></script>
     </environment>
 
     <environment names="Staging,Production">
         <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
     </environment>
     
     <partial name="_DatatablesScriptsPartial" />
-
-    <script>
-        $(function() {
-            $('[data-toggle="tooltip"]').tooltip();
-        });
-    </script>
+    <script src="~/js/tacos-ui.js" asp-append-version="true"></script>
 
     @RenderSection("scripts", required: false)
 

--- a/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
+++ b/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
@@ -7,12 +7,12 @@
     var departmentSelectItems = departments.Select(d => new SelectListItem() { Text = d.Name, Value = d.Id.ToString() });
 }
 
-<div class="mx-auto max-w-screen-xl space-y-6 px-4 py-6">
+<div class="tacos-page-shell tacos-page-stack">
 
-    <h2>Manage Department Roles</h2>
+    <h2 class="tacos-page-heading">Manage Department Roles</h2>
 
-    <div class="overflow-x-auto">
-        <table id="departmentRolesTable" class="table table-zebra w-full">
+    <div>
+        <table id="departmentRolesTable" class="table tacos-admin-roles-table tacos-department-roles-table w-full">
             <thead>
             <tr>
                 <th></th>
@@ -47,8 +47,8 @@
         Add User to Department
     </button>
 
-    <dialog id="addUserToDepartmentRoleModal" class="modal modal-top tacos-dialog" aria-labelledby="addUserToDepartmentRoleModalTitle">
-        <div class="modal-box tacos-modal__content" role="document">
+    <dialog id="addUserToDepartmentRoleModal" class="tacos-dialog tacos-dialog--top" aria-labelledby="addUserToDepartmentRoleModalTitle">
+        <div class="tacos-dialog__panel tacos-modal__content" role="document">
             <div class="tacos-modal__header">
                 <h5 class="tacos-modal__title" id="addUserToDepartmentRoleModalTitle">Add User to Department</h5>
                 <button type="button" class="tacos-modal__close" aria-label="Close" onclick="this.closest('dialog').close()">
@@ -72,7 +72,7 @@
                 </div>
             </form>
         </div>
-        <form method="dialog" class="modal-backdrop">
+        <form method="dialog" class="tacos-dialog__backdrop">
             <button aria-label="Close dialog">close</button>
         </form>
     </dialog>

--- a/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
+++ b/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
@@ -7,41 +7,43 @@
     var departmentSelectItems = departments.Select(d => new SelectListItem() { Text = d.Name, Value = d.Id.ToString() });
 }
 
-<div class="container">
+<div class="mx-auto max-w-screen-xl space-y-6 px-4 py-6">
 
     <h2>Manage Department Roles</h2>
 
-    <table id="departmentRolesTable" class="table table-striped">
-        <thead>
-        <tr>
-            <th></th>
-            <th>Code</th>
-            <th>Department</th>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Role</th>
-        </tr>
-        </thead>
-        <tbody>
-        @foreach (var row in Model.DepartmentRoles)
-        {
+    <div class="overflow-x-auto">
+        <table id="departmentRolesTable" class="table table-zebra w-full">
+            <thead>
             <tr>
-                <td>
-                    <form method="post" asp-action="RemoveUserToDepartmentRole" asp-route-userId="@row.UserId" asp-route-departmentId="@row.DepartmentId" asp-antiforgery="true">
-                        <button class="btn btn-danger" type="submit"><i class="fas fa-trash"></i></button>
-                    </form>
-                </td>
-                <td>@row.Department.Code</td>
-                <td>@row.Department.Name</td>
-                <td>@row.User.Name</td>
-                <td>@row.User.Email</td>
-                <td>@row.Role</td>
+                <th></th>
+                <th>Code</th>
+                <th>Department</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Role</th>
             </tr>
-        }
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+            @foreach (var row in Model.DepartmentRoles)
+            {
+                <tr>
+                    <td>
+                        <form method="post" asp-action="RemoveUserToDepartmentRole" asp-route-userId="@row.UserId" asp-route-departmentId="@row.DepartmentId" asp-antiforgery="true">
+                            <button class="tacos-btn tacos-btn--danger tacos-btn--icon-only" type="submit"><i class="fas fa-trash"></i></button>
+                        </form>
+                    </td>
+                    <td>@row.Department.Code</td>
+                    <td>@row.Department.Name</td>
+                    <td>@row.User.Name</td>
+                    <td>@row.User.Email</td>
+                    <td>@row.Role</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
 
-    <button type="button" class="btn btn-primary" onclick="document.getElementById('addUserToDepartmentRoleModal').showModal()">
+    <button type="button" class="tacos-btn tacos-btn--primary" onclick="document.getElementById('addUserToDepartmentRoleModal').showModal()">
         Add User to Department
     </button>
 

--- a/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
+++ b/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
@@ -41,38 +41,39 @@
         </tbody>
     </table>
 
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addUserToDepartmentRoleModal">
+    <button type="button" class="btn btn-primary" onclick="document.getElementById('addUserToDepartmentRoleModal').showModal()">
         Add User to Department
     </button>
 
-    <form method="post" asp-action="AddUserToDepartmentRole">
-        <div id="addUserToDepartmentRoleModal" class="modal" tabindex="-1" role="dialog">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Modal title</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+    <dialog id="addUserToDepartmentRoleModal" class="modal modal-top tacos-dialog" aria-labelledby="addUserToDepartmentRoleModalTitle">
+        <div class="modal-box tacos-modal__content" role="document">
+            <div class="tacos-modal__header">
+                <h5 class="tacos-modal__title" id="addUserToDepartmentRoleModalTitle">Add User to Department</h5>
+                <button type="button" class="tacos-modal__close" aria-label="Close" onclick="this.closest('dialog').close()">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <form method="post" asp-action="AddUserToDepartmentRole">
+                <div class="tacos-modal__body">
+                    <div class="tacos-form-field">
+                        <label class="tacos-form-label">Department</label>
+                        <select name="departmentId" class="tacos-select" asp-items="departmentSelectItems" autofocus></select>
                     </div>
-                    <div class="modal-body">
-                        <div class="form-group">
-                            <label class="control-label">Department</label>
-                            <select name="departmentId" class="form-control" asp-items="departmentSelectItems"></select>
-                        </div>
-                        <div class="form-group">
-                            <label class="control-label">User</label>
-                            <input name="userId" class="form-control" />
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                        <button type="submit" class="btn btn-primary">Add User</button>
+                    <div class="tacos-form-field">
+                        <label class="tacos-form-label">User</label>
+                        <input name="userId" class="tacos-input" />
                     </div>
                 </div>
-            </div>
+                <div class="tacos-modal__footer">
+                    <button type="button" class="tacos-btn tacos-btn--secondary" onclick="this.closest('dialog').close()">Close</button>
+                    <button type="submit" class="tacos-btn tacos-btn--primary">Add User</button>
+                </div>
+            </form>
         </div>
-    </form>
+        <form method="dialog" class="modal-backdrop">
+            <button aria-label="Close dialog">close</button>
+        </form>
+    </dialog>
 
 </div>
 
@@ -86,7 +87,8 @@
                         "targets": [0],
                         "sortable": false
                     }],
-                "order": [[1, "desc"]]
+                "order": [[1, "desc"]],
+                "dom": window.TacosDataTables.dom.standard
             });
         });
 </script>

--- a/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
+++ b/src/tacos.mvc/Views/System/DepartmentUsers.cshtml
@@ -29,7 +29,9 @@
                 <tr>
                     <td>
                         <form method="post" asp-action="RemoveUserToDepartmentRole" asp-route-userId="@row.UserId" asp-route-departmentId="@row.DepartmentId" asp-antiforgery="true">
-                            <button class="tacos-btn tacos-btn--danger tacos-btn--icon-only" type="submit"><i class="fas fa-trash"></i></button>
+                            <button class="tacos-btn tacos-btn--danger tacos-btn--icon-only" type="submit" aria-label="Remove @row.User.Name from @row.Department.Name" title="Remove @row.User.Name from @row.Department.Name">
+                                <i class="fas fa-trash" aria-hidden="true"></i>
+                            </button>
                         </form>
                     </td>
                     <td>@row.Department.Code</td>
@@ -58,12 +60,12 @@
             <form method="post" asp-action="AddUserToDepartmentRole">
                 <div class="tacos-modal__body">
                     <div class="tacos-form-field">
-                        <label class="tacos-form-label">Department</label>
-                        <select name="departmentId" class="tacos-select" asp-items="departmentSelectItems" autofocus></select>
+                        <label class="tacos-form-label" for="departmentRoleDepartmentId">Department</label>
+                        <select id="departmentRoleDepartmentId" name="departmentId" class="tacos-select" asp-items="departmentSelectItems" autofocus></select>
                     </div>
                     <div class="tacos-form-field">
-                        <label class="tacos-form-label">User</label>
-                        <input name="userId" class="tacos-input" />
+                        <label class="tacos-form-label" for="departmentRoleUserId">User</label>
+                        <input id="departmentRoleUserId" name="userId" class="tacos-input" type="text" />
                     </div>
                 </div>
                 <div class="tacos-modal__footer">
@@ -83,6 +85,13 @@
 {
 <script>
         $(function () {
+            var defaultDom = "<'tacos-datatable-toolbar'<'tacos-datatable-toolbar__length'l><'tacos-datatable-toolbar__actions'f>>" +
+                "<'tacos-datatable-table'tr>" +
+                "<'tacos-datatable-footer'<'tacos-datatable-footer__info'i><'tacos-datatable-footer__pagination'p>>";
+            var dataTableDom = window.TacosDataTables && window.TacosDataTables.dom && window.TacosDataTables.dom.standard
+                ? window.TacosDataTables.dom.standard
+                : defaultDom;
+
             $('#departmentRolesTable').DataTable({
                 "columnDefs": [
                     {
@@ -90,7 +99,7 @@
                         "sortable": false
                     }],
                 "order": [[1, "desc"]],
-                "dom": window.TacosDataTables.dom.standard
+                "dom": dataTableDom
             });
         });
 </script>

--- a/src/tacos.mvc/Views/System/Index.cshtml
+++ b/src/tacos.mvc/Views/System/Index.cshtml
@@ -4,21 +4,16 @@
 @{
 }
 
-<div class="mx-auto max-w-3xl px-4 py-6">
-    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
-        <div class="card-body">
-            <h2 class="card-title text-2xl">System Tools</h2>
-            <ul class="menu gap-2 rounded-none bg-base-100 p-0">
-                <li>
-                    <a asp-action="SystemUsers">Manage System Roles</a>
-                </li>
-                <li>
-                    <a asp-action="DepartmentUsers">Manage Department Users</a>
-                </li>
-                <li>
-                    <a asp-action="ManageSubmissions">Manage Submissions</a>
-                </li>
-            </ul>
-        </div>
-    </div>
+<div class="tacos-page-shell">
+    <ul class="tacos-link-list">
+        <li>
+            <a asp-action="SystemUsers">Manage System Roles</a>
+        </li>
+        <li>
+            <a asp-action="DepartmentUsers">Manage Department Users</a>
+        </li>
+        <li>
+            <a asp-action="ManageSubmissions">Manage Submissions</a>
+        </li>
+    </ul>
 </div>

--- a/src/tacos.mvc/Views/System/Index.cshtml
+++ b/src/tacos.mvc/Views/System/Index.cshtml
@@ -4,16 +4,21 @@
 @{
 }
 
-<div class="container py-4">
-    <ul>
-        <li>
-            <a asp-action="SystemUsers">Manage System Roles</a>
-        </li>
-        <li>
-            <a asp-action="DepartmentUsers">Manage Department Users</a>
-        </li>
-        <li>
-            <a asp-action="ManageSubmissions">Manage Submissions</a>
-        </li>
-    </ul>
+<div class="mx-auto max-w-3xl px-4 py-6">
+    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
+        <div class="card-body">
+            <h2 class="card-title text-2xl">System Tools</h2>
+            <ul class="menu gap-2 rounded-none bg-base-100 p-0">
+                <li>
+                    <a asp-action="SystemUsers">Manage System Roles</a>
+                </li>
+                <li>
+                    <a asp-action="DepartmentUsers">Manage Department Users</a>
+                </li>
+                <li>
+                    <a asp-action="ManageSubmissions">Manage Submissions</a>
+                </li>
+            </ul>
+        </div>
+    </div>
 </div>

--- a/src/tacos.mvc/Views/System/ManageSubmissions.cshtml
+++ b/src/tacos.mvc/Views/System/ManageSubmissions.cshtml
@@ -2,17 +2,13 @@
     ViewBag.Title = "Manage Submissions";
 }
 
-<div class="mx-auto max-w-3xl px-4 py-6">
-    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
-        <div class="card-body space-y-4">
-            <h2 class="card-title text-2xl">Reset All Submissions</h2>
-            <p>
-                Warning: Clicking "Reset" will remove all exceptions and place every submission back in an "unsubmitted status".
-                You probably only want to do this once a year when you are ready to start over with fresh data.
-            </p>
-            <form method="post" asp-action="ResetSubmissions" asp-antiforgery="true">
-                <button class="tacos-btn tacos-btn--danger" type="submit">Reset All Submissions <i class="fas fa-trash tacos-btn__icon"></i></button>
-            </form>
-        </div>
-    </div>
+<div class="tacos-page-shell">
+    <form method="post" asp-action="ResetSubmissions" asp-antiforgery="true">
+        <h2 class="tacos-page-heading">Reset All Submissions</h2>
+        <p class="mt-6 mb-4">
+            Warning: Clicking "Reset" will remove all exceptions and place every submission back in an "unsubmitted status".
+            You probably only want to do this once a year when you are ready to start over with fresh data.
+        </p>
+        <button class="tacos-btn tacos-btn--danger" type="submit">Reset All Submissions <i class="fas fa-trash tacos-btn__icon"></i></button>
+    </form>
 </div>

--- a/src/tacos.mvc/Views/System/ManageSubmissions.cshtml
+++ b/src/tacos.mvc/Views/System/ManageSubmissions.cshtml
@@ -2,13 +2,17 @@
     ViewBag.Title = "Manage Submissions";
 }
 
-<div class="container">
-    <form method="post" asp-action="ResetSubmissions" asp-antiforgery="true">
-        <h2>Reset All Submissions</h2>
-        <p>
-            Warning: Clicking "Reset" will remove all exceptions and place every submission back in an "unsubmitted status".  
-            You probably only want to do this once a year when you are ready to start over with fresh data.
-        </p>
-        <button class="btn btn-danger" type="submit">Reset All Submissions <i class="fas fa-trash"></i></button>
-    </form>
+<div class="mx-auto max-w-3xl px-4 py-6">
+    <div class="card rounded-none border border-base-300 bg-base-100 shadow-sm">
+        <div class="card-body space-y-4">
+            <h2 class="card-title text-2xl">Reset All Submissions</h2>
+            <p>
+                Warning: Clicking "Reset" will remove all exceptions and place every submission back in an "unsubmitted status".
+                You probably only want to do this once a year when you are ready to start over with fresh data.
+            </p>
+            <form method="post" asp-action="ResetSubmissions" asp-antiforgery="true">
+                <button class="tacos-btn tacos-btn--danger" type="submit">Reset All Submissions <i class="fas fa-trash tacos-btn__icon"></i></button>
+            </form>
+        </div>
+    </div>
 </div>

--- a/src/tacos.mvc/Views/System/SystemUsers.cshtml
+++ b/src/tacos.mvc/Views/System/SystemUsers.cshtml
@@ -5,58 +5,60 @@
     ViewBag.Title = "Manage User Roles";
 }
 
-<div class="container">
+<div class="mx-auto max-w-screen-xl px-4 py-6">
     <h2>Manage System Roles</h2>
 
-    <table id="table" class="table table-striped">
-        <thead>
-            <tr>
-                <th></th>
-                <th>Name</th>
-                <th>Email</th>
-                <th>Is Admin</th>
-                <th>Is Reviewer</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var row in Model.SystemRoles)
-            {
+    <div class="overflow-x-auto">
+        <table id="table" class="table table-zebra w-full">
+            <thead>
                 <tr>
-                    <td>
-
-                        @if (row.IsAdmin)
-                        {
-                            <form method="post" asp-action="RemoveUserFromRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Admin asp-route-add="false" asp-antiforgery="true">
-                                <button class="btn btn-danger" type="submit"><i class="fas fa-trash"></i> Admin</button>
-                            </form>
-                        }
-                        else
-                        {
-                            <form method="post" asp-action="AddUserToRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Admin asp-route-add="true" asp-antiforgery="true">
-                                <button class="btn btn-primary" type="submit"><i class="fas fa-plus"></i> Admin</button>
-                            </form>
-                        }
-                        <hr />
-                        @if (row.IsReviewer)
-                        {
-                            <form method="post" asp-action="RemoveUserFromRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Reviewer asp-route-add="false" asp-antiforgery="true">
-                                <button class="btn btn-danger" type="submit"><i class="fas fa-trash"></i> Reviewer</button>
-                            </form>
-                        }
-                        else
-                        {
-                            <form method="post" asp-action="AddUserToRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Reviewer asp-route-add="true" asp-antiforgery="true">
-                                <button class="btn btn-primary" type="submit"><i class="fas fa-plus"></i> Reviewer</button>
-                            </form>
-                        }
-
-                    </td>
-                    <td>@row.User.Name</td>
-                    <td>@row.User.Email</td>
-                    <td>@row.IsAdmin</td>
-                    <td>@row.IsReviewer</td>
+                    <th></th>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Is Admin</th>
+                    <th>Is Reviewer</th>
                 </tr>
-            }
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+                @foreach (var row in Model.SystemRoles)
+                {
+                    <tr>
+                        <td>
+                            <div class="flex flex-col items-start gap-2">
+                                @if (row.IsAdmin)
+                                {
+                                    <form method="post" asp-action="RemoveUserFromRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Admin asp-route-add="false" asp-antiforgery="true">
+                                        <button class="tacos-btn tacos-btn--danger" type="submit"><i class="fas fa-trash tacos-inline-icon-start"></i>Admin</button>
+                                    </form>
+                                }
+                                else
+                                {
+                                    <form method="post" asp-action="AddUserToRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Admin asp-route-add="true" asp-antiforgery="true">
+                                        <button class="tacos-btn tacos-btn--primary" type="submit"><i class="fas fa-plus tacos-inline-icon-start"></i>Admin</button>
+                                    </form>
+                                }
+                                <div class="h-px w-full bg-base-300"></div>
+                                @if (row.IsReviewer)
+                                {
+                                    <form method="post" asp-action="RemoveUserFromRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Reviewer asp-route-add="false" asp-antiforgery="true">
+                                        <button class="tacos-btn tacos-btn--danger" type="submit"><i class="fas fa-trash tacos-inline-icon-start"></i>Reviewer</button>
+                                    </form>
+                                }
+                                else
+                                {
+                                    <form method="post" asp-action="AddUserToRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Reviewer asp-route-add="true" asp-antiforgery="true">
+                                        <button class="tacos-btn tacos-btn--primary" type="submit"><i class="fas fa-plus tacos-inline-icon-start"></i>Reviewer</button>
+                                    </form>
+                                }
+                            </div>
+                        </td>
+                        <td>@row.User.Name</td>
+                        <td>@row.User.Email</td>
+                        <td>@row.IsAdmin</td>
+                        <td>@row.IsReviewer</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
 </div>

--- a/src/tacos.mvc/Views/System/SystemUsers.cshtml
+++ b/src/tacos.mvc/Views/System/SystemUsers.cshtml
@@ -5,11 +5,11 @@
     ViewBag.Title = "Manage User Roles";
 }
 
-<div class="mx-auto max-w-screen-xl px-4 py-6">
-    <h2>Manage System Roles</h2>
+<div class="tacos-page-shell">
+    <h2 class="tacos-page-heading">Manage System Roles</h2>
 
-    <div class="overflow-x-auto">
-        <table id="table" class="table table-zebra w-full">
+    <div>
+        <table id="table" class="table tacos-admin-roles-table tacos-system-roles-table w-full">
             <thead>
                 <tr>
                     <th></th>
@@ -24,7 +24,7 @@
                 {
                     <tr>
                         <td>
-                            <div class="flex flex-col items-start gap-2">
+                            <div class="tacos-system-roles-table__actions">
                                 @if (row.IsAdmin)
                                 {
                                     <form method="post" asp-action="RemoveUserFromRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Admin asp-route-add="false" asp-antiforgery="true">
@@ -37,7 +37,7 @@
                                         <button class="tacos-btn tacos-btn--primary" type="submit"><i class="fas fa-plus tacos-inline-icon-start"></i>Admin</button>
                                     </form>
                                 }
-                                <div class="h-px w-full bg-base-300"></div>
+                                <div class="tacos-system-roles-table__actions-divider"></div>
                                 @if (row.IsReviewer)
                                 {
                                     <form method="post" asp-action="RemoveUserFromRole" asp-route-userId="@row.User.Id" asp-route-role=@RoleCodes.Reviewer asp-route-add="false" asp-antiforgery="true">

--- a/src/tacos.mvc/eslint.config.mjs
+++ b/src/tacos.mvc/eslint.config.mjs
@@ -1,0 +1,44 @@
+import nkzw from "@nkzw/eslint-config";
+
+export default [
+  ...nkzw,
+  {
+    ignores: [
+      "ClientApp/build/",
+      "bin/",
+      "node_modules/",
+      "obj/",
+      "vite.config.ts.timestamp-*",
+      "webpack.config.js",
+    ],
+  },
+  {
+    rules: {
+      "@nkzw/no-instanceof": "off",
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "import-x/no-namespace": "off",
+      "no-console": "off",
+      "perfectionist/sort-interfaces": "off",
+      "perfectionist/sort-jsx-props": "off",
+      "perfectionist/sort-objects": "off",
+      "unicorn/catch-error-name": "off",
+      "unicorn/consistent-function-scoping": "off",
+      "unicorn/prefer-at": "off",
+      "unicorn/prefer-dom-node-append": "off",
+      "unicorn/prefer-number-properties": "off",
+      "unicorn/prefer-string-replace-all": "off",
+      "unicorn/prefer-ternary": "off",
+    },
+  },
+  {
+    settings: {
+      "import/resolver": {
+        typescript: {
+          alwaysTryTypes: true,
+          project: "./tsconfig.json",
+        },
+      },
+    },
+  },
+];

--- a/src/tacos.mvc/package-lock.json
+++ b/src/tacos.mvc/package-lock.json
@@ -15,12 +15,16 @@
         "react-dom": "^19.2.4"
       },
       "devDependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@ucdavis/gunrock-tailwind": "^2.5.1",
         "@vitejs/plugin-react": "^6.0.1",
+        "daisyui": "^5.5.19",
         "jsdom": "^29.0.0",
         "kill-port": "^2.0.1",
         "sass": "^1.93.2",
+        "tailwindcss": "^4.2.2",
         "tslint": "^5.12.0",
         "tslint-config-prettier": "^1.17.0",
         "tslint-react": "^4.1.0",
@@ -328,12 +332,55 @@
         }
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
@@ -941,6 +988,278 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -1036,6 +1355,17 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@ucdavis/gunrock-tailwind": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@ucdavis/gunrock-tailwind/-/gunrock-tailwind-2.5.1.tgz",
+      "integrity": "sha512-hQY2ARsJKqOgQpcgrdQatDdZ1QEYKGx9eUzoew1NvmGMz65wHbRLNMmjuPZ7NX1FlbTvYpy6cN/8eYY0PBpCXA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "daisyui": "^5.0.0",
+        "tailwindcss": "^4.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1348,6 +1678,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/daisyui": {
+      "version": "5.5.19",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
+      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -1396,6 +1736,20 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -1553,6 +1907,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1662,6 +2023,16 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2466,6 +2837,27 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/src/tacos.mvc/package-lock.json
+++ b/src/tacos.mvc/package-lock.json
@@ -15,12 +15,14 @@
         "react-dom": "^19.2.4"
       },
       "devDependencies": {
+        "@nkzw/eslint-config": "^3.3.0",
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@ucdavis/gunrock-tailwind": "^2.5.1",
         "@vitejs/plugin-react": "^6.0.1",
         "daisyui": "^5.5.19",
+        "eslint": "^9.39.4",
         "jsdom": "^29.0.0",
         "kill-port": "^2.0.1",
         "sass": "^1.93.2",
@@ -93,12 +95,257 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -314,6 +561,183 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -330,6 +754,58 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -399,6 +875,41 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@nkzw/eslint-config": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@nkzw/eslint-config/-/eslint-config-3.3.0.tgz",
+      "integrity": "sha512-TmxbVKQDFdh+bO9jDN9278qNWyQLVzYs5vEVQIv2PmYqLyyzrxywHvbFxb76j6yRQTphC6anNMAyVy+uTYKy/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/js": "^9.39.2",
+        "@nkzw/eslint-plugin": "^2.0.0",
+        "@typescript-eslint/parser": "^8.50.0",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import-x": "^4.16.1",
+        "eslint-plugin-no-only-tests": "^3.3.0",
+        "eslint-plugin-perfectionist": "^5.0.0",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-unicorn": "^62.0.0",
+        "eslint-plugin-unused-imports": "~4.3.0",
+        "globals": "^16.5.0",
+        "typescript-eslint": "^8.50.0"
+      },
+      "peerDependencies": {
+        "eslint": ">= 9"
+      }
+    },
+    "node_modules/@nkzw/eslint-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nkzw/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
+      "integrity": "sha512-IoU8kOqHfnf7se2dGxMD/7RPm6WVjzjOjWSo7FulRx3lJzuZvXioSkT5Nd82l66DH3Pl2whw74lPT1di3KMwFA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">= 9"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.120.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
@@ -408,6 +919,13 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@package-json/types": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+      "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
@@ -1337,6 +1855,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1357,6 +1882,275 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@ucdavis/gunrock-tailwind": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@ucdavis/gunrock-tailwind/-/gunrock-tailwind-2.5.1.tgz",
@@ -1367,6 +2161,288 @@
         "daisyui": "^5.0.0",
         "tailwindcss": "^4.0.0"
       }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1507,6 +2583,46 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -1530,6 +2646,144 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1540,12 +2794,51 @@
         "node": ">=12"
       }
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -1568,6 +2861,40 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1577,6 +2904,87 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1603,6 +3011,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1617,6 +3032,35 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/color-convert": {
@@ -1643,6 +3087,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
+      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1656,6 +3110,35 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -1702,6 +3185,78 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -1716,6 +3271,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/detect-libc": {
@@ -1737,6 +3335,41 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -1765,12 +3398,199 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -1780,6 +3600,532 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+      "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@package-json/types": "^0.0.12",
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.8.0.tgz",
+      "integrity": "sha512-k8uIptWIxkUclonCFGyDzgYs9NI+Qh0a7cUXS3L7IYZDEsjXuimFBVbxXPQQngWqMiaxJRwbtYB4smMGMqF+cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.58.0",
+        "natural-orderby": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.45.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "62.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz",
+      "integrity": "sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@eslint-community/eslint-utils": "^4.9.0",
+        "@eslint/plugin-kit": "^0.4.0",
+        "change-case": "^5.4.4",
+        "ci-info": "^4.3.1",
+        "clean-regexp": "^1.0.0",
+        "core-js-compat": "^3.46.0",
+        "esquery": "^1.6.0",
+        "find-up-simple": "^1.0.1",
+        "globals": "^16.4.0",
+        "indent-string": "^5.0.0",
+        "is-builtin-module": "^5.0.0",
+        "jsesc": "^3.1.0",
+        "pluralize": "^8.0.0",
+        "regexp-tree": "^0.1.27",
+        "regjsparser": "^0.13.0",
+        "semver": "^7.7.3",
+        "strip-indent": "^4.1.1"
+      },
+      "engines": {
+        "node": "^20.10.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.38.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.3.0.tgz",
+      "integrity": "sha512-ZFBmXMGBYfHttdRtOG9nFFpmUvMtbHSjsKrS20vdWdbfiVYsO3yA2SGYy9i9XmZJDfMGBflZGBCm70SEnFQtOA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -1796,6 +4142,42 @@
         "node": ">=4"
       }
     },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1804,6 +4186,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1815,6 +4207,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1834,6 +4247,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/filter-obj": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
@@ -1844,6 +4270,73 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fs.realpath": {
@@ -1878,12 +4371,133 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-them-args": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
       "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1907,12 +4521,81 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -1922,6 +4605,64 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -1937,6 +4678,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -1950,12 +4708,62 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1976,6 +4784,144 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
+      "integrity": "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-builtin-module/node_modules/builtin-modules": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.1.0.tgz",
+      "integrity": "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -1992,15 +4938,85 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -2009,12 +5025,54 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2023,6 +5081,183 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2096,6 +5331,79 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kill-port": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-2.0.1.tgz",
@@ -2108,6 +5416,20 @@
       },
       "bin": {
         "kill-port": "cli.js"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -2371,6 +5693,42 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -2389,6 +5747,16 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
@@ -2434,6 +5802,13 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2453,6 +5828,39 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-orderby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
+      "integrity": "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -2460,6 +5868,150 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -2482,6 +6034,87 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -2495,6 +6128,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2503,6 +6146,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -2539,6 +6192,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -2568,11 +6241,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-checkbox": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pretty-checkbox/-/pretty-checkbox-3.0.3.tgz",
       "integrity": "sha512-kCLsENsJ6h5Bcq106Q3YMSxuz2q3jtIXP7fgDB/+jZjUsZjRjAoL9Lr1TVwAEcugufVBhr5Mfd9L7P6d+SR+Yw==",
       "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2622,6 +6317,13 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2634,6 +6336,73 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
       }
     },
     "node_modules/require-from-string": {
@@ -2665,6 +6434,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rolldown": {
@@ -2708,6 +6497,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/sass": {
       "version": "1.98.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
@@ -2748,12 +6592,173 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shell-exec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
       "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2791,6 +6796,16 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2804,6 +6819,144 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -2949,6 +7102,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3053,6 +7219,97 @@
         "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3067,6 +7324,49 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/undici": {
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
@@ -3075,6 +7375,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -3285,6 +7661,111 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3300,6 +7781,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrappy": {
@@ -3325,6 +7816,49 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/src/tacos.mvc/package.json
+++ b/src/tacos.mvc/package.json
@@ -10,6 +10,7 @@
     "start": "npx kill-port 5173 && vite",
     "debug": "ASPNETCORE_ENVIRONMENT=Development dotnet watch run",
     "build": "vite build",
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest watch"
   },
@@ -21,12 +22,14 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "@nkzw/eslint-config": "^3.3.0",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@ucdavis/gunrock-tailwind": "^2.5.1",
     "@vitejs/plugin-react": "^6.0.1",
     "daisyui": "^5.5.19",
+    "eslint": "^9.39.4",
     "jsdom": "^29.0.0",
     "kill-port": "^2.0.1",
     "sass": "^1.93.2",

--- a/src/tacos.mvc/package.json
+++ b/src/tacos.mvc/package.json
@@ -21,12 +21,16 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@ucdavis/gunrock-tailwind": "^2.5.1",
     "@vitejs/plugin-react": "^6.0.1",
+    "daisyui": "^5.5.19",
     "jsdom": "^29.0.0",
     "kill-port": "^2.0.1",
     "sass": "^1.93.2",
+    "tailwindcss": "^4.2.2",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.17.0",
     "tslint-react": "^4.1.0",

--- a/src/tacos.mvc/vite.config.ts
+++ b/src/tacos.mvc/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
     root: "ClientApp",
@@ -7,7 +8,7 @@ export default defineConfig({
         outDir: "build",
         emptyOutDir: true,
     },
-    plugins: [react()],
+    plugins: [react(), tailwindcss()],
     server: {
         port: 5173,
         strictPort: true,

--- a/src/tacos.mvc/wwwroot/js/tacos-ui.js
+++ b/src/tacos.mvc/wwwroot/js/tacos-ui.js
@@ -1,0 +1,43 @@
+(function () {
+    "use strict";
+
+    function toggleCollapse(button) {
+        var targetSelector = button.getAttribute("data-tacos-collapse-target");
+
+        if (!targetSelector) {
+            return;
+        }
+
+        var target = document.querySelector(targetSelector);
+
+        if (!target) {
+            return;
+        }
+
+        var isExpanded = target.classList.toggle("show");
+        button.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+    }
+
+    function dismissAlert(button) {
+        var alertElement = button.closest(".alert");
+
+        if (alertElement) {
+            alertElement.remove();
+        }
+    }
+
+    document.addEventListener("click", function (event) {
+        var collapseButton = event.target.closest("[data-tacos-collapse-target]");
+
+        if (collapseButton) {
+            toggleCollapse(collapseButton);
+            return;
+        }
+
+        var alertDismissButton = event.target.closest("[data-tacos-dismiss='alert']");
+
+        if (alertDismissButton) {
+            dismissAlert(alertDismissButton);
+        }
+    });
+})();

--- a/src/tacos.mvc/wwwroot/js/tacos-ui.js
+++ b/src/tacos.mvc/wwwroot/js/tacos-ui.js
@@ -26,15 +26,39 @@
         }
     }
 
+    function closeDialog(dialog) {
+        if (dialog && dialog.open) {
+            dialog.close();
+        }
+    }
+
     document.addEventListener("click", function (event) {
-        var collapseButton = event.target.closest("[data-tacos-collapse-target]");
+        var target = event.target instanceof Element ? event.target : null;
+
+        if (!target) {
+            return;
+        }
+
+        var dialogBackdrop = target.closest(".tacos-dialog__backdrop");
+
+        if (dialogBackdrop) {
+            closeDialog(dialogBackdrop.closest("dialog.tacos-dialog"));
+            return;
+        }
+
+        if (target instanceof HTMLDialogElement && target.classList.contains("tacos-dialog")) {
+            closeDialog(target);
+            return;
+        }
+
+        var collapseButton = target.closest("[data-tacos-collapse-target]");
 
         if (collapseButton) {
             toggleCollapse(collapseButton);
             return;
         }
 
-        var alertDismissButton = event.target.closest("[data-tacos-dismiss='alert']");
+        var alertDismissButton = target.closest("[data-tacos-dismiss='alert']");
 
         if (alertDismissButton) {
             dismissAlert(alertDismissButton);

--- a/src/tacos.mvc/wwwroot/js/tacos-ui.js
+++ b/src/tacos.mvc/wwwroot/js/tacos-ui.js
@@ -14,7 +14,7 @@
             return;
         }
 
-        var isExpanded = target.classList.toggle("show");
+        var isExpanded = target.classList.toggle("is-open");
         button.setAttribute("aria-expanded", isExpanded ? "true" : "false");
     }
 

--- a/src/tacos.mvc/wwwroot/js/tacos-ui.js
+++ b/src/tacos.mvc/wwwroot/js/tacos-ui.js
@@ -2,24 +2,24 @@
     "use strict";
 
     function toggleCollapse(button) {
-        var targetSelector = button.getAttribute("data-tacos-collapse-target");
+        const targetSelector = button.getAttribute("data-tacos-collapse-target");
 
         if (!targetSelector) {
             return;
         }
 
-        var target = document.querySelector(targetSelector);
+        const target = document.querySelector(targetSelector);
 
         if (!target) {
             return;
         }
 
-        var isExpanded = target.classList.toggle("is-open");
+        const isExpanded = target.classList.toggle("is-open");
         button.setAttribute("aria-expanded", isExpanded ? "true" : "false");
     }
 
     function dismissAlert(button) {
-        var alertElement = button.closest(".alert");
+        const alertElement = button.closest(".alert");
 
         if (alertElement) {
             alertElement.remove();
@@ -32,14 +32,14 @@
         }
     }
 
-    document.addEventListener("click", function (event) {
-        var target = event.target instanceof Element ? event.target : null;
+    document.addEventListener("click", (event) => {
+        const target = event.target;
 
-        if (!target) {
+        if (!(target instanceof Element)) {
             return;
         }
 
-        var dialogBackdrop = target.closest(".tacos-dialog__backdrop");
+        const dialogBackdrop = target.closest(".tacos-dialog__backdrop");
 
         if (dialogBackdrop) {
             closeDialog(dialogBackdrop.closest("dialog.tacos-dialog"));
@@ -51,14 +51,14 @@
             return;
         }
 
-        var collapseButton = target.closest("[data-tacos-collapse-target]");
+        const collapseButton = target.closest("[data-tacos-collapse-target]");
 
         if (collapseButton) {
             toggleCollapse(collapseButton);
             return;
         }
 
-        var alertDismissButton = target.closest("[data-tacos-dismiss='alert']");
+        const alertDismissButton = target.closest("[data-tacos-dismiss='alert']");
 
         if (alertDismissButton) {
             dismissAlert(alertDismissButton);


### PR DESCRIPTION
This PR completes the Bootstrap 4 to Tailwind/DaisyUI migration across the React and Razor surfaces while keeping the app visually aligned with the existing UC Davis styling.

It replaces Bootstrap JS behaviors with app-owned implementations, migrates Razor modals to native <dialog>, moves shared React modal/tooltip usage onto app-owned styling, updates DataTables/layout/form/table styling to no longer depend on Bootstrap CSS, and removes the remaining Bootstrap-specific markup/hooks where practical. It also includes a broad regression-fix pass to restore the prior look and feel across Requests, Review, Approval, System, Home, and account/admin pages.

Notes:

- jQuery is intentionally retained for DataTables and unobtrusive validation.

Verification:

- npm run build
- npm test (48/48 passing)
- dotnet test src/tacos.mvc/tacos.mvc.csproj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Tailwind/DaisyUI-based stylesheet and site UI script enabling native dialog modals, collapse/dismiss behaviors, and updated theme.

* **Bug Fixes & Improvements**
  * Stabilized test selectors and form inputs; updated DataTables layout templates and client lint step in CI.
  * Request list behavior: persisted rows ordered before unsaved entries; create-focus updated.

* **Style**
  * Large visual refresh: buttons, forms, tables, tooltips, modals, and page/layout utilities updated for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->