### PR TITLE
Add TrustServerCertificate to DefaultConnection

### DIFF
--- a/src/tacos.mvc/appsettings.json
+++ b/src/tacos.mvc/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=.\\sqlexpress;Database=tacos;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=.\\sqlexpress;Database=tacos;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=true"
   },
   "Common": {
     "CasBaseUrl": "https://ssodev.ucdavis.edu/cas/",


### PR DESCRIPTION
Updates the local SQL Express connection string to include TrustServerCertificate=True, resolving SSL/TLS connection issues common in newer versions of the SQL Server driver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection settings to improve connectivity reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->