### PR TITLE
Update grading intensive course label

### DIFF
--- a/src/tacos.core/Resources/CourseInfo.cs
+++ b/src/tacos.core/Resources/CourseInfo.cs
@@ -7,7 +7,7 @@ namespace tacos.core.Resources
         public static readonly Dictionary<string, string> Types =
             new Dictionary<string, string> {
                 { "STD", "Standard lecture with sections" },
-                { "WRT", "Grading intensive lecture with sections" },
+                { "WRT", "Grading intensive lecture classes with sections" },
                 { "LAB", "Lab or Studio classes" },
                 { "FLD", "Field classes" },
                 { "AUTO", "Lecture only, automated grading" },

--- a/src/tacos.mvc/ClientApp/components/CourseType.tsx
+++ b/src/tacos.mvc/ClientApp/components/CourseType.tsx
@@ -28,7 +28,7 @@ export default class CourseType extends React.PureComponent<IProps, {}> {
 
 export const CourseTypeOptions = [
     [ "STD", "Standard lecture with sections" ],
-    [ "WRT", "Grading intensive lecture with sections" ],
+    [ "WRT", "Grading intensive lecture classes with sections" ],
     [ "LAB", "Lab or Studio classes" ],
     [ "FLD", "Field classes" ],
     [ "AUTO", "Lecture only, automated grading" ],


### PR DESCRIPTION
## Summary

- Update the WRT course type label to "Grading intensive lecture classes with sections" in the server-side course type map.
- Update the matching React dropdown option so client-side editing uses the same label.

## Impact

This aligns the TACOS course category wording with the requested grading-intensive terminology before testing.

Closes #155

## Verification

- `npm run lint`
- `npm run test`
- `npm run build`
- `dotnet build src/tacos.core/tacos.core.csproj`
- `dotnet build src/tacos.mvc/tacos.mvc.csproj`
- `dotnet test Test/Test.csproj`
- `npx -y react-doctor@latest . --verbose --diff`
