### PR TITLE
Use source academic years for course rebuild term spans

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ An **Academic Term Code** present in **CourseOfferingsRaw** and therefore eligib
 _Avoid_: Manually typed term code
 
 **Academic Year Span**:
-A human-readable academic year label such as `2024-25`.
+A human-readable label composed from the `AcademicYear` values in **CourseOfferingsRaw**, such as `2024-25 and 2025-26`.
 _Avoid_: Ending-year-only label
 
 **Most Recent Academic Year**:
@@ -71,8 +71,8 @@ _Avoid_: Duplicate course
 - A valid **Processing Window** contains exactly two academic years, each with the required `10`, `01`, and `03` terms.
 - Users select **Available Term Codes** directly or choose an **Academic Year Span** helper that derives the six-code **Processing Window**.
 - The frontend previews the six **Academic Term Codes** represented by each **Academic Year Span** selection.
-- The frontend lists **Academic Year Span** helpers derived from **Available Term Codes**.
-- When users choose an **Academic Year Span**, that span is the later year in the two-year **Processing Window**.
+- The frontend lists **Academic Year Span** helpers derived from **CourseOfferingsRaw** `AcademicYear` values for the selected term codes.
+- When users choose an **Academic Year Span**, the underlying processing key remains the later year in the two-year **Processing Window**.
 - An **Academic Year Span** helper is valid only when all six implied **Academic Term Codes** are present in **CourseOfferingsRaw**.
 - `WasCourseTaughtInMostRecentYear` is true when a course appears in the **Most Recent Academic Year**.
 - `IsCourseTaughtOnceEveryTwoYears` is true when a course is an **Every-Other-Year Course**.

--- a/Test/Services/CourseRebuildServiceTests.cs
+++ b/Test/Services/CourseRebuildServiceTests.cs
@@ -24,7 +24,7 @@ namespace Test.Services
             var options = await service.GetAcademicYearSpanOptionsAsync();
 
             options.Count.ShouldBe(2);
-            options[0].AcademicYearSpan.ShouldBe("2025-26");
+            options[0].AcademicYearSpan.ShouldBe("2024-25 and 2025-26");
             options[0].IsComplete.ShouldBeTrue();
             options[0].Terms.Select(t => t.AcademicTermCode).ShouldBe(new[]
             {
@@ -35,7 +35,7 @@ namespace Test.Services
                 "202601",
                 "202603"
             });
-            options[1].AcademicYearSpan.ShouldBe("2024-25");
+            options[1].AcademicYearSpan.ShouldBe("2023-24 and 2024-25");
             options[1].IsComplete.ShouldBeFalse();
         }
 
@@ -68,7 +68,7 @@ namespace Test.Services
                 "202601",
                 "202603"
             });
-            result.AcademicYearSpan.ShouldBe("2025-26");
+            result.AcademicYearSpan.ShouldBe("2024-25 and 2025-26");
             result.StartingAcademicYear.ShouldBe(2025);
         }
 
@@ -171,7 +171,7 @@ namespace Test.Services
                 $"{startingAcademicYear + 1}01",
                 $"{startingAcademicYear + 1}03"
             };
-            var span = $"{startingAcademicYear}-{(startingAcademicYear + 1) % 100:00}";
+            var span = $"{startingAcademicYear - 1}-{startingAcademicYear % 100:00} and {startingAcademicYear}-{(startingAcademicYear + 1) % 100:00}";
 
             for (var i = 0; i < termCodes.Length; i++)
             {

--- a/src/tacos.core/Migrations/20260518133000_CourseRebuildLabelsUseSourceAcademicYears.cs
+++ b/src/tacos.core/Migrations/20260518133000_CourseRebuildLabelsUseSourceAcademicYears.cs
@@ -1,0 +1,216 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace tacos.core.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(TacoDbContext))]
+    [Migration("20260518133000_CourseRebuildLabelsUseSourceAcademicYears")]
+    public partial class CourseRebuildLabelsUseSourceAcademicYears : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                CREATE OR ALTER PROCEDURE [dbo].[usp_GetCourseRebuildAcademicYearSpanOptions]
+                AS
+                BEGIN
+                    SET NOCOUNT ON;
+
+                    IF OBJECT_ID(N'[dbo].[CourseOfferingsRaw]', N'U') IS NULL
+                    BEGIN
+                        THROW 50000, 'CourseOfferingsRaw source table is required before course rebuild options can be listed.', 1;
+                    END;
+
+                    ;WITH AvailableTermCodes AS
+                    (
+                        SELECT DISTINCT
+                            LTRIM(RTRIM([AcademicTermCode])) AS [AcademicTermCode],
+                            NULLIF(LTRIM(RTRIM(CONVERT(nvarchar(20), [AcademicYear]))), N'') AS [AcademicYear]
+                        FROM [dbo].[CourseOfferingsRaw]
+                        WHERE [AcademicTermCode] IS NOT NULL
+                            AND LEN(LTRIM(RTRIM([AcademicTermCode]))) = 6
+                            AND TRY_CONVERT(int, LEFT(LTRIM(RTRIM([AcademicTermCode])), 4)) IS NOT NULL
+                            AND RIGHT(LTRIM(RTRIM([AcademicTermCode])), 2) IN (N'10', N'01', N'03')
+                    ),
+                    AvailableAcademicYears AS
+                    (
+                        SELECT DISTINCT
+                            CASE
+                                WHEN RIGHT([AcademicTermCode], 2) = N'10'
+                                    THEN TRY_CONVERT(int, LEFT([AcademicTermCode], 4))
+                                ELSE TRY_CONVERT(int, LEFT([AcademicTermCode], 4)) - 1
+                            END AS [AcademicYearStart]
+                        FROM AvailableTermCodes
+                    ),
+                    RequiredTerms AS
+                    (
+                        SELECT
+                            AcademicYears.[AcademicYearStart] AS [LaterAcademicYearStart],
+                            TermValues.[TermOrder],
+                            TermValues.[AcademicTermCode]
+                        FROM AvailableAcademicYears AcademicYears
+                        CROSS APPLY
+                        (
+                            VALUES
+                                (1, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart] - 1) + N'10'),
+                                (2, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart]) + N'01'),
+                                (3, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart]) + N'03'),
+                                (4, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart]) + N'10'),
+                                (5, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart] + 1) + N'01'),
+                                (6, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart] + 1) + N'03')
+                        ) TermValues([TermOrder], [AcademicTermCode])
+                    ),
+                    RequiredTermsWithAvailability AS
+                    (
+                        SELECT
+                            RequiredTerms.[LaterAcademicYearStart],
+                            RequiredTerms.[TermOrder],
+                            RequiredTerms.[AcademicTermCode],
+                            SourceYears.[AcademicYear],
+                            CASE
+                                WHEN SourceYears.[AcademicTermCode] IS NULL THEN 0
+                                ELSE 1
+                            END AS [IsAvailable]
+                        FROM RequiredTerms
+                        OUTER APPLY
+                        (
+                            SELECT TOP (1)
+                                AvailableTermCodes.[AcademicTermCode],
+                                AvailableTermCodes.[AcademicYear]
+                            FROM AvailableTermCodes
+                            WHERE AvailableTermCodes.[AcademicTermCode] = RequiredTerms.[AcademicTermCode]
+                            ORDER BY AvailableTermCodes.[AcademicYear]
+                        ) SourceYears
+                    ),
+                    AcademicYearLabels AS
+                    (
+                        SELECT
+                            LabelTerms.[LaterAcademicYearStart],
+                            STUFF(
+                                (
+                                    SELECT N' and ' + LabelYears.[AcademicYear]
+                                    FROM
+                                    (
+                                        SELECT DISTINCT
+                                            [LaterAcademicYearStart],
+                                            [AcademicYear]
+                                        FROM RequiredTermsWithAvailability
+                                        WHERE [AcademicYear] IS NOT NULL
+                                    ) LabelYears
+                                    WHERE LabelYears.[LaterAcademicYearStart] = LabelTerms.[LaterAcademicYearStart]
+                                    ORDER BY LabelYears.[AcademicYear]
+                                    FOR XML PATH(N''), TYPE
+                                ).value(N'.', N'nvarchar(max)'),
+                                1,
+                                5,
+                                N''
+                            ) AS [AcademicYearSpan]
+                        FROM RequiredTermsWithAvailability LabelTerms
+                        GROUP BY LabelTerms.[LaterAcademicYearStart]
+                    )
+                    SELECT
+                        COALESCE(
+                            AcademicYearLabels.[AcademicYearSpan],
+                            CONVERT(nvarchar(4), RequiredTermsWithAvailability.[LaterAcademicYearStart]) + N'-' + RIGHT(CONVERT(nvarchar(4), RequiredTermsWithAvailability.[LaterAcademicYearStart] + 1), 2)
+                        ) AS [AcademicYearSpan],
+                        RequiredTermsWithAvailability.[LaterAcademicYearStart] AS [StartingAcademicYear],
+                        RequiredTermsWithAvailability.[AcademicTermCode],
+                        RequiredTermsWithAvailability.[TermOrder],
+                        CAST(RequiredTermsWithAvailability.[IsAvailable] AS bit) AS [IsAvailable],
+                        CAST(MIN(RequiredTermsWithAvailability.[IsAvailable]) OVER (PARTITION BY RequiredTermsWithAvailability.[LaterAcademicYearStart]) AS bit) AS [IsComplete]
+                    FROM RequiredTermsWithAvailability
+                    LEFT JOIN AcademicYearLabels
+                        ON AcademicYearLabels.[LaterAcademicYearStart] = RequiredTermsWithAvailability.[LaterAcademicYearStart]
+                    ORDER BY RequiredTermsWithAvailability.[LaterAcademicYearStart] DESC, RequiredTermsWithAvailability.[TermOrder];
+                END;
+                """,
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                CREATE OR ALTER PROCEDURE [dbo].[usp_GetCourseRebuildAcademicYearSpanOptions]
+                AS
+                BEGIN
+                    SET NOCOUNT ON;
+
+                    IF OBJECT_ID(N'[dbo].[CourseOfferingsRaw]', N'U') IS NULL
+                    BEGIN
+                        THROW 50000, 'CourseOfferingsRaw source table is required before course rebuild options can be listed.', 1;
+                    END;
+
+                    ;WITH AvailableTermCodes AS
+                    (
+                        SELECT DISTINCT LTRIM(RTRIM([AcademicTermCode])) AS [AcademicTermCode]
+                        FROM [dbo].[CourseOfferingsRaw]
+                        WHERE [AcademicTermCode] IS NOT NULL
+                            AND LEN(LTRIM(RTRIM([AcademicTermCode]))) = 6
+                            AND TRY_CONVERT(int, LEFT(LTRIM(RTRIM([AcademicTermCode])), 4)) IS NOT NULL
+                            AND RIGHT(LTRIM(RTRIM([AcademicTermCode])), 2) IN (N'10', N'01', N'03')
+                    ),
+                    AvailableAcademicYears AS
+                    (
+                        SELECT DISTINCT
+                            CASE
+                                WHEN RIGHT([AcademicTermCode], 2) = N'10'
+                                    THEN TRY_CONVERT(int, LEFT([AcademicTermCode], 4))
+                                ELSE TRY_CONVERT(int, LEFT([AcademicTermCode], 4)) - 1
+                            END AS [AcademicYearStart]
+                        FROM AvailableTermCodes
+                    ),
+                    RequiredTerms AS
+                    (
+                        SELECT
+                            AcademicYears.[AcademicYearStart] AS [LaterAcademicYearStart],
+                            TermValues.[TermOrder],
+                            TermValues.[AcademicTermCode]
+                        FROM AvailableAcademicYears AcademicYears
+                        CROSS APPLY
+                        (
+                            VALUES
+                                (1, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart] - 1) + N'10'),
+                                (2, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart]) + N'01'),
+                                (3, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart]) + N'03'),
+                                (4, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart]) + N'10'),
+                                (5, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart] + 1) + N'01'),
+                                (6, CONVERT(nvarchar(4), AcademicYears.[AcademicYearStart] + 1) + N'03')
+                        ) TermValues([TermOrder], [AcademicTermCode])
+                    ),
+                    RequiredTermsWithAvailability AS
+                    (
+                        SELECT
+                            RequiredTerms.[LaterAcademicYearStart],
+                            RequiredTerms.[TermOrder],
+                            RequiredTerms.[AcademicTermCode],
+                            CASE
+                                WHEN AvailableTermCodes.[AcademicTermCode] IS NULL THEN 0
+                                ELSE 1
+                            END AS [IsAvailable]
+                        FROM RequiredTerms
+                        LEFT JOIN AvailableTermCodes
+                            ON AvailableTermCodes.[AcademicTermCode] = RequiredTerms.[AcademicTermCode]
+                    )
+                    SELECT
+                        CONVERT(nvarchar(4), [LaterAcademicYearStart]) + N'-' + RIGHT(CONVERT(nvarchar(4), [LaterAcademicYearStart] + 1), 2) AS [AcademicYearSpan],
+                        [LaterAcademicYearStart] AS [StartingAcademicYear],
+                        [AcademicTermCode],
+                        [TermOrder],
+                        CAST([IsAvailable] AS bit) AS [IsAvailable],
+                        CAST(MIN([IsAvailable]) OVER (PARTITION BY [LaterAcademicYearStart]) AS bit) AS [IsComplete]
+                    FROM RequiredTermsWithAvailability
+                    ORDER BY [LaterAcademicYearStart] DESC, [TermOrder];
+                END;
+                """,
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/src/tacos.core/Migrations/20260518133000_CourseRebuildLabelsUseSourceAcademicYears.cs
+++ b/src/tacos.core/Migrations/20260518133000_CourseRebuildLabelsUseSourceAcademicYears.cs
@@ -83,7 +83,9 @@ namespace tacos.core.Migrations
                                 AvailableTermCodes.[AcademicYear]
                             FROM AvailableTermCodes
                             WHERE AvailableTermCodes.[AcademicTermCode] = RequiredTerms.[AcademicTermCode]
-                            ORDER BY AvailableTermCodes.[AcademicYear]
+                            ORDER BY
+                                CASE WHEN AvailableTermCodes.[AcademicYear] IS NULL THEN 1 ELSE 0 END,
+                                AvailableTermCodes.[AcademicYear]
                         ) SourceYears
                     ),
                     AcademicYearLabels AS

--- a/src/tacos.core/Migrations/20260518134500_CourseOfferingsRawTermYearIndex.cs
+++ b/src/tacos.core/Migrations/20260518134500_CourseOfferingsRawTermYearIndex.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace tacos.core.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(TacoDbContext))]
+    [Migration("20260518134500_CourseOfferingsRawTermYearIndex")]
+    public partial class CourseOfferingsRawTermYearIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                IF OBJECT_ID(N'[dbo].[CourseOfferingsRaw]', N'U') IS NOT NULL
+                    AND NOT EXISTS
+                    (
+                        SELECT 1
+                        FROM sys.indexes
+                        WHERE object_id = OBJECT_ID(N'[dbo].[CourseOfferingsRaw]')
+                            AND name = N'IX_CourseOfferingsRaw_AcademicTermCode_AcademicYear'
+                    )
+                BEGIN
+                    CREATE NONCLUSTERED INDEX [IX_CourseOfferingsRaw_AcademicTermCode_AcademicYear]
+                    ON [dbo].[CourseOfferingsRaw] ([AcademicTermCode], [AcademicYear]);
+                END;
+                """,
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                IF OBJECT_ID(N'[dbo].[CourseOfferingsRaw]', N'U') IS NOT NULL
+                    AND EXISTS
+                    (
+                        SELECT 1
+                        FROM sys.indexes
+                        WHERE object_id = OBJECT_ID(N'[dbo].[CourseOfferingsRaw]')
+                            AND name = N'IX_CourseOfferingsRaw_AcademicTermCode_AcademicYear'
+                    )
+                BEGIN
+                    DROP INDEX [IX_CourseOfferingsRaw_AcademicTermCode_AcademicYear]
+                    ON [dbo].[CourseOfferingsRaw];
+                END;
+                """,
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/src/tacos.mvc/Services/CourseRebuildService.cs
+++ b/src/tacos.mvc/Services/CourseRebuildService.cs
@@ -99,7 +99,7 @@ namespace tacos.mvc.services
 
             return new CourseRebuildResultModel
             {
-                AcademicYearSpan = processingWindow.AcademicYearSpan,
+                AcademicYearSpan = matchingOption.AcademicYearSpan,
                 StartingAcademicYear = processingWindow.StartingAcademicYear,
                 AcademicTermCodes = processingWindow.AcademicTermCodes.ToList()
             };


### PR DESCRIPTION
## Summary
- Build course rebuild academic year span labels from CourseOfferingsRaw.AcademicYear values
- Return the selected display label after rebuild validation
- Add a covering CourseOfferingsRaw index for the rebuild options query
- Update service tests and domain notes for the new label semantics

## Testing
- dotnet test Test/Test.csproj
- dotnet ef database update --project src/tacos.core --startup-project src/tacos.mvc
- Verified dbo.usp_GetCourseRebuildAcademicYearSpanOptions returns labels like 2024-25 and 2025-26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Academic year span labels now show combined multi-year ranges (e.g., "2024-25 and 2025-26") instead of single-year labels.

* **Database**
  * Updated course-rebuild label generation and added an index to improve course-rebuild query performance.

* **Tests**
  * Updated tests and test data to expect combined multi-year academic year span labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/tacos/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->