### PR TITLE
Add expandable TACOS FAQ page

### DIFF
--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -634,6 +634,47 @@ hr {
   text-decoration: underline;
 }
 
+.tacos-faq {
+  max-width: 58rem;
+
+  h3 {
+    color: $primary-color;
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.3;
+    margin: 0 0 0.75rem;
+  }
+
+  p,
+  li {
+    line-height: 1.6;
+  }
+
+  p,
+  ol,
+  ul {
+    margin-bottom: 0;
+  }
+
+  ol,
+  ul {
+    padding-left: 1.5rem;
+  }
+
+  li + li {
+    margin-top: 0.5rem;
+  }
+}
+
+.tacos-faq__item {
+  border-top: 1px solid #d6d6d6;
+  padding: 1.5rem 0;
+}
+
+.tacos-faq__item > * + * {
+  margin-top: 0.75rem;
+}
+
 .tacos-admin-panel {
   max-width: 42rem;
 }

--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -637,14 +637,6 @@ hr {
 .tacos-faq {
   max-width: 58rem;
 
-  h3 {
-    color: $primary-color;
-    font-size: 1.25rem;
-    font-weight: 700;
-    line-height: 1.3;
-    margin: 0 0 0.75rem;
-  }
-
   p,
   li {
     line-height: 1.6;
@@ -666,13 +658,83 @@ hr {
   }
 }
 
-.tacos-faq__item {
-  border-top: 1px solid #d6d6d6;
-  padding: 1.5rem 0;
+.tacos-faq__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
 }
 
-.tacos-faq__item > * + * {
+.tacos-faq__item {
+  border-top: 1px solid #d6d6d6;
+}
+
+.tacos-faq__item:last-child {
+  border-bottom: 1px solid #d6d6d6;
+}
+
+.tacos-faq__item > summary {
+  align-items: flex-start;
+  color: $primary-color;
+  cursor: pointer;
+  display: flex;
+  font-size: 1.15rem;
+  font-weight: 700;
+  gap: 1rem;
+  justify-content: space-between;
+  line-height: 1.35;
+  list-style: none;
+  padding: 1rem 0;
+}
+
+.tacos-faq__item > summary::-webkit-details-marker {
+  display: none;
+}
+
+.tacos-faq__item > summary::after {
+  content: "+";
+  flex: 0 0 auto;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.tacos-faq__item[open] > summary::after {
+  content: "-";
+}
+
+.tacos-faq__item > summary:hover,
+.tacos-faq__item > summary:focus,
+.tacos-faq__item > summary:focus-visible {
+  color: #2f5b8c;
+}
+
+.tacos-faq__item > summary:focus-visible {
+  outline: 2px solid rgba(0, 123, 255, 0.25);
+  outline-offset: 0.25rem;
+}
+
+.tacos-faq__answer {
+  padding: 0 0 1.5rem;
+}
+
+.tacos-faq__answer > * + * {
   margin-top: 0.75rem;
+}
+
+.tacos-faq__question {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 640px) {
+  .tacos-faq__header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tacos-faq__header .tacos-btn {
+    width: 100%;
+  }
 }
 
 .tacos-admin-panel {

--- a/src/tacos.mvc/Controllers/FaqsController.cs
+++ b/src/tacos.mvc/Controllers/FaqsController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace tacos.mvc.Controllers
+{
+    public class FaqsController : ApplicationController
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/src/tacos.mvc/Views/Faqs/Index.cshtml
+++ b/src/tacos.mvc/Views/Faqs/Index.cshtml
@@ -1,0 +1,98 @@
+@{
+    ViewData["Title"] = "FAQ";
+}
+
+<div class="tacos-page-shell">
+    <article class="tacos-faq">
+        <header class="tacos-page-header">
+            <h2 class="tacos-page-heading">TACOS FAQs</h2>
+        </header>
+
+        <section class="tacos-faq__item">
+            <h3>What are the different types of courses listed in TACOS?</h3>
+            <p>The eight different categories of courses in TACOS include:</p>
+            <ol>
+                <li>Standard lecture classes with sections</li>
+                <li>
+                    Grading intensive lecture classes with sections
+                    <ul>
+                        <li>Writing intensive: includes GE writing designation or &gt; 10-page papers.</li>
+                        <li>Project-based: with a substantial project that comprises at least 50% of the total course grade and requires input from faculty/TA's over more than two class meetings for organization planning, implementation and/or evaluation/grading of student work.</li>
+                        <li>Quantitative: has weekly hand-graded problem sets.</li>
+                        <li>Writing intensive or substantial project courses will typically have approved course learning activities listed in the catalog of "Extensive Problem Solving," "Extensive Writing," or "GE Writing Experience."</li>
+                    </ul>
+                </li>
+                <li>Lab or studio classes</li>
+                <li>Field courses</li>
+                <li>Lecture-only classes, automated grading (no sections, grading is by Scantron, Canvas quizzes or similar)</li>
+                <li>Lecture-only classes, manual grading (tests require grader attention)</li>
+                <li>Lecture-only classes, moderate writing (5-10-page papers)</li>
+                <li>Lecture-only classes, writing intensive or substantial project. No sections; GE writing or &gt; 10-page papers. A substantial project is a project that comprises at least 25% of the total course grade and requires input from faculty/TA's over more than one class meeting for organization planning, implementation and/or evaluation/grading of student work. Quantitative courses have weekly hand-graded problem sets. Writing intensive or substantial project courses will typically have approved course learning activities listed in the catalog of "Extensive Problem Solving," "Extensive Writing," or "GE Writing Experience."</li>
+            </ol>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>How do I determine the correct class type for a lecture-only class?</h3>
+            <p>Lecture-only, writing intensive or substantial project courses will typically be listed in the catalog as "Extensive Problem Solving," "Extensive Writing," and/or "GE Writing Experience." The other criteria (automated grading, manual grading, moderate writing) will require consultation with instructors of record to understand grading modes specific to the courses.</p>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>How do I request funding for TAs/Readers for my course?</h3>
+            <p>Each department creates its own protocol to request TAs/Readers funding. The best practice is for decision-makers to consult with faculty teaching the courses to determine course types before requests are submitted in TACOS. Once decisions are made, the departments (usually a vice chair/lead faculty advisor, CAO, or teaching coordinator) submit entries annually in the online TA Calculation Application (TACOS) system to request Dean's Office funding. Questions can be directed to your CAO. These requests are approved or denied by the executive assistant dean in consultation with the associate dean for Undergraduate Academic Programs.</p>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>How do I determine what course type to select in making a TACOS request?</h3>
+            <p>Requested course types should be consistent with approved learning activities in the General Catalog and as outlined by the UC Davis Academic Senate Committee on Courses of Instruction (COCI) Policies and Procedures.</p>
+            <ul>
+                <li>Course information from the General Catalog is provided in TACOS.</li>
+                <li>If a catalog description is outdated or a course format has changed, departments should submit a request through the Integrated Curriculum Management System (ICMS).</li>
+                <li>A careful review is needed of the course types submitted since there are discrepancies between what is listed in the catalog current course types and what is requested.</li>
+            </ul>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>What is the Dean's Office process for allocating funds for TAs and Readers?</h3>
+            <p>TAs and Readers are hired by departments based on instructional need. Departments submit entries annually in the TACOS system to request Dean's Office funding.</p>
+            <ul>
+                <li>Standard requests consist of course number and course type (such as field classes, lecture-only with manual grading, etc.).</li>
+                <li>Departments may submit exception requests for courses that do not automatically align with the existing criteria. Exception requests include fields from the standard request plus the proposed TA and/or Reader %, proposed number of course offerings and a reason for the request.</li>
+                <li>These requests are approved or denied by the executive assistant dean in consultation with the associate dean for Undergraduate Academic Programs. Funds are allocated annually by the Dean's Office to departments. Departments can elect to hire additional TAs and Readers at their own expense.</li>
+                <li>Recognizing there are unforeseeable changes throughout the year, departments can choose to reallocate funds based on their own internal needs. However, all instructional support requests for TAs and Readers and allocations from the college will be based on approved college-level criteria.</li>
+                <li>For approved requests, the Dean's Office provides funding for salaries and benefits. The campus provides funding for the current-year's incremental wage increases. Campus also covers the cost of fee remissions for TAs and Readers appointed at a minimum of 25% time for the quarter.</li>
+                <li>In July before fiscal close, the Dean's Office pulls back any remaining funds in the chart strings for temporary teaching support. There is currently no differentiation between remaining balances tied to TAs/Readers versus Lecturers. Any overdrafts need to be funded by the department before fiscal close, so the new fiscal year starts with a zero balance.</li>
+            </ul>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>What are the responsibilities of a Teaching Assistant (TA)?</h3>
+            <p>Under the active direction and supervision of a regular member of faculty to whom responsibility for the course's entire instruction has been assigned, TAs are responsible for the conduct of recitation, laboratory, and/or quiz sections. A TA is not responsible for instructional content of a course, selection of student assignments, planning of examinations, or determining the term grade for students. The TA is not responsible for instructing the entire enrollment of a course or for providing online instruction to a group of students enrolled in a course. Per campus policy APM 410-20 and guidance from November 2025, TAs can be responsible for conducting office hours.</p>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>What are the responsibilities of a Reader?</h3>
+            <p>Readers are employed for the ability to render diverse services as a "course assistant," which normally includes grading student papers and examinations. Readers can also answer questions about grading. A Reader should not be given the responsibilities customarily accorded a Teaching Assistant. Per campus policy APM 420-4 and guidance from November 2025, Readers should not be responsible for holding office hours.</p>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>Is there a class size limit for assigning a Reader?</h3>
+            <p>Campus policy APM 420-21 states, while there is no specific limit to the size of classes for which Readers may be appointed, it is expected that the staff member giving the instruction will perform the reading without appointed Readers in a class of 30 students.</p>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>How are TAs and Readers paid?</h3>
+            <p>TA and Reader positions approved through the CA&amp;ES Dean's Office are funded from Tuition Revenues. Salary scales are posted on the Graduate Studies website. TAs and Readers appointed at a minimum appointment level of 25% are eligible for tuition and fees that are paid centrally through campus allocations. Minimum eligibility and restrictions for academic appointment of graduate students are outlined on the Graduate Studies website.</p>
+            <p>Template appointment letters and descriptions of expectations and duties for all academic student employees are available on the Graduate Studies website. Departments are strongly encouraged to use these templates for hiring TAs and Readers to best ensure compliance with policies.</p>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>Where does TACOS get its data?</h3>
+            <p>Information in TACOS is a combination of user-entered data and data extracted from the campus course catalog and historical actual student enrollment from the past two years in Banner. Eligibility criteria are set by a faculty-led committee, which have been updated for the 2026-27 academic year.</p>
+        </section>
+
+        <section class="tacos-faq__item">
+            <h3>How should I code TAs and Readers in Aggie Enterprise?</h3>
+            <p>Effective July 1, 2026, TAs and Readers must be paid in chart strings using the 200638 - Teaching Assistants activity code in Aggie Enterprise.</p>
+        </section>
+    </article>
+</div>

--- a/src/tacos.mvc/Views/Faqs/Index.cshtml
+++ b/src/tacos.mvc/Views/Faqs/Index.cshtml
@@ -3,96 +3,143 @@
 }
 
 <div class="tacos-page-shell">
-    <article class="tacos-faq">
-        <header class="tacos-page-header">
+    <article class="tacos-faq" data-tacos-faq>
+        <header class="tacos-page-header tacos-faq__header">
             <h2 class="tacos-page-heading">TACOS FAQs</h2>
+            <button class="tacos-btn tacos-btn--secondary" type="button" data-tacos-faq-toggle data-expand-label="Expand all" data-collapse-label="Collapse all" aria-expanded="false">
+                Expand all
+            </button>
         </header>
 
-        <section class="tacos-faq__item">
-            <h3>What are the different types of courses listed in TACOS?</h3>
-            <p>The eight different categories of courses in TACOS include:</p>
-            <ol>
-                <li>Standard lecture classes with sections</li>
-                <li>
-                    Grading intensive lecture classes with sections
-                    <ul>
-                        <li>Writing intensive: includes GE writing designation or &gt; 10-page papers.</li>
-                        <li>Project-based: with a substantial project that comprises at least 50% of the total course grade and requires input from faculty/TA's over more than two class meetings for organization planning, implementation and/or evaluation/grading of student work.</li>
-                        <li>Quantitative: has weekly hand-graded problem sets.</li>
-                        <li>Writing intensive or substantial project courses will typically have approved course learning activities listed in the catalog of "Extensive Problem Solving," "Extensive Writing," or "GE Writing Experience."</li>
-                    </ul>
-                </li>
-                <li>Lab or studio classes</li>
-                <li>Field courses</li>
-                <li>Lecture-only classes, automated grading (no sections, grading is by Scantron, Canvas quizzes or similar)</li>
-                <li>Lecture-only classes, manual grading (tests require grader attention)</li>
-                <li>Lecture-only classes, moderate writing (5-10-page papers)</li>
-                <li>Lecture-only classes, writing intensive or substantial project. No sections; GE writing or &gt; 10-page papers. A substantial project is a project that comprises at least 25% of the total course grade and requires input from faculty/TA's over more than one class meeting for organization planning, implementation and/or evaluation/grading of student work. Quantitative courses have weekly hand-graded problem sets. Writing intensive or substantial project courses will typically have approved course learning activities listed in the catalog of "Extensive Problem Solving," "Extensive Writing," or "GE Writing Experience."</li>
-            </ol>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">What are the different types of courses listed in TACOS?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>The eight different categories of courses in TACOS include:</p>
+                <ol>
+                    <li>Standard lecture classes with sections</li>
+                    <li>
+                        Grading intensive lecture classes with sections
+                        <ul>
+                            <li>Writing intensive: includes GE writing designation or &gt; 10-page papers.</li>
+                            <li>Project-based: with a substantial project that comprises at least 50% of the total course grade and requires input from faculty/TA's over more than two class meetings for organization planning, implementation and/or evaluation/grading of student work.</li>
+                            <li>Quantitative: has weekly hand-graded problem sets.</li>
+                            <li>Writing intensive or substantial project courses will typically have approved course learning activities listed in the catalog of "Extensive Problem Solving," "Extensive Writing," or "GE Writing Experience."</li>
+                        </ul>
+                    </li>
+                    <li>Lab or studio classes</li>
+                    <li>Field courses</li>
+                    <li>Lecture-only classes, automated grading (no sections, grading is by Scantron, Canvas quizzes or similar)</li>
+                    <li>Lecture-only classes, manual grading (tests require grader attention)</li>
+                    <li>Lecture-only classes, moderate writing (5-10-page papers)</li>
+                    <li>Lecture-only classes, writing intensive or substantial project. No sections; GE writing or &gt; 10-page papers. A substantial project is a project that comprises at least 25% of the total course grade and requires input from faculty/TA's over more than one class meeting for organization planning, implementation and/or evaluation/grading of student work. Quantitative courses have weekly hand-graded problem sets. Writing intensive or substantial project courses will typically have approved course learning activities listed in the catalog of "Extensive Problem Solving," "Extensive Writing," or "GE Writing Experience."</li>
+                </ol>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>How do I determine the correct class type for a lecture-only class?</h3>
-            <p>Lecture-only, writing intensive or substantial project courses will typically be listed in the catalog as "Extensive Problem Solving," "Extensive Writing," and/or "GE Writing Experience." The other criteria (automated grading, manual grading, moderate writing) will require consultation with instructors of record to understand grading modes specific to the courses.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">How do I determine the correct class type for a lecture-only class?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Lecture-only, writing intensive or substantial project courses will typically be listed in the catalog as "Extensive Problem Solving," "Extensive Writing," and/or "GE Writing Experience." The other criteria (automated grading, manual grading, moderate writing) will require consultation with instructors of record to understand grading modes specific to the courses.</p>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>How do I request funding for TAs/Readers for my course?</h3>
-            <p>Each department creates its own protocol to request TAs/Readers funding. The best practice is for decision-makers to consult with faculty teaching the courses to determine course types before requests are submitted in TACOS. Once decisions are made, the departments (usually a vice chair/lead faculty advisor, CAO, or teaching coordinator) submit entries annually in the online TA Calculation Application (TACOS) system to request Dean's Office funding. Questions can be directed to your CAO. These requests are approved or denied by the executive assistant dean in consultation with the associate dean for Undergraduate Academic Programs.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">How do I request funding for TAs/Readers for my course?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Each department creates its own protocol to request TAs/Readers funding. The best practice is for decision-makers to consult with faculty teaching the courses to determine course types before requests are submitted in TACOS. Once decisions are made, the departments (usually a vice chair/lead faculty advisor, CAO, or teaching coordinator) submit entries annually in the online TA Calculation Application (TACOS) system to request Dean's Office funding. Questions can be directed to your CAO. These requests are approved or denied by the executive assistant dean in consultation with the associate dean for Undergraduate Academic Programs.</p>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>How do I determine what course type to select in making a TACOS request?</h3>
-            <p>Requested course types should be consistent with approved learning activities in the General Catalog and as outlined by the UC Davis Academic Senate Committee on Courses of Instruction (COCI) Policies and Procedures.</p>
-            <ul>
-                <li>Course information from the General Catalog is provided in TACOS.</li>
-                <li>If a catalog description is outdated or a course format has changed, departments should submit a request through the Integrated Curriculum Management System (ICMS).</li>
-                <li>A careful review is needed of the course types submitted since there are discrepancies between what is listed in the catalog current course types and what is requested.</li>
-            </ul>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">How do I determine what course type to select in making a TACOS request?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Requested course types should be consistent with approved learning activities in the General Catalog and as outlined by the UC Davis Academic Senate Committee on Courses of Instruction (COCI) Policies and Procedures.</p>
+                <ul>
+                    <li>Course information from the General Catalog is provided in TACOS.</li>
+                    <li>If a catalog description is outdated or a course format has changed, departments should submit a request through the Integrated Curriculum Management System (ICMS).</li>
+                    <li>A careful review is needed of the course types submitted since there are discrepancies between what is listed in the catalog current course types and what is requested.</li>
+                </ul>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>What is the Dean's Office process for allocating funds for TAs and Readers?</h3>
-            <p>TAs and Readers are hired by departments based on instructional need. Departments submit entries annually in the TACOS system to request Dean's Office funding.</p>
-            <ul>
-                <li>Standard requests consist of course number and course type (such as field classes, lecture-only with manual grading, etc.).</li>
-                <li>Departments may submit exception requests for courses that do not automatically align with the existing criteria. Exception requests include fields from the standard request plus the proposed TA and/or Reader %, proposed number of course offerings and a reason for the request.</li>
-                <li>These requests are approved or denied by the executive assistant dean in consultation with the associate dean for Undergraduate Academic Programs. Funds are allocated annually by the Dean's Office to departments. Departments can elect to hire additional TAs and Readers at their own expense.</li>
-                <li>Recognizing there are unforeseeable changes throughout the year, departments can choose to reallocate funds based on their own internal needs. However, all instructional support requests for TAs and Readers and allocations from the college will be based on approved college-level criteria.</li>
-                <li>For approved requests, the Dean's Office provides funding for salaries and benefits. The campus provides funding for the current-year's incremental wage increases. Campus also covers the cost of fee remissions for TAs and Readers appointed at a minimum of 25% time for the quarter.</li>
-                <li>In July before fiscal close, the Dean's Office pulls back any remaining funds in the chart strings for temporary teaching support. There is currently no differentiation between remaining balances tied to TAs/Readers versus Lecturers. Any overdrafts need to be funded by the department before fiscal close, so the new fiscal year starts with a zero balance.</li>
-            </ul>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">What is the Dean's Office process for allocating funds for TAs and Readers?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>TAs and Readers are hired by departments based on instructional need. Departments submit entries annually in the TACOS system to request Dean's Office funding.</p>
+                <ul>
+                    <li>Standard requests consist of course number and course type (such as field classes, lecture-only with manual grading, etc.).</li>
+                    <li>Departments may submit exception requests for courses that do not automatically align with the existing criteria. Exception requests include fields from the standard request plus the proposed TA and/or Reader %, proposed number of course offerings and a reason for the request.</li>
+                    <li>These requests are approved or denied by the executive assistant dean in consultation with the associate dean for Undergraduate Academic Programs. Funds are allocated annually by the Dean's Office to departments. Departments can elect to hire additional TAs and Readers at their own expense.</li>
+                    <li>Recognizing there are unforeseeable changes throughout the year, departments can choose to reallocate funds based on their own internal needs. However, all instructional support requests for TAs and Readers and allocations from the college will be based on approved college-level criteria.</li>
+                    <li>For approved requests, the Dean's Office provides funding for salaries and benefits. The campus provides funding for the current-year's incremental wage increases. Campus also covers the cost of fee remissions for TAs and Readers appointed at a minimum of 25% time for the quarter.</li>
+                    <li>In July before fiscal close, the Dean's Office pulls back any remaining funds in the chart strings for temporary teaching support. There is currently no differentiation between remaining balances tied to TAs/Readers versus Lecturers. Any overdrafts need to be funded by the department before fiscal close, so the new fiscal year starts with a zero balance.</li>
+                </ul>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>What are the responsibilities of a Teaching Assistant (TA)?</h3>
-            <p>Under the active direction and supervision of a regular member of faculty to whom responsibility for the course's entire instruction has been assigned, TAs are responsible for the conduct of recitation, laboratory, and/or quiz sections. A TA is not responsible for instructional content of a course, selection of student assignments, planning of examinations, or determining the term grade for students. The TA is not responsible for instructing the entire enrollment of a course or for providing online instruction to a group of students enrolled in a course. Per campus policy APM 410-20 and guidance from November 2025, TAs can be responsible for conducting office hours.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">What are the responsibilities of a Teaching Assistant (TA)?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Under the active direction and supervision of a regular member of faculty to whom responsibility for the course's entire instruction has been assigned, TAs are responsible for the conduct of recitation, laboratory, and/or quiz sections. A TA is not responsible for instructional content of a course, selection of student assignments, planning of examinations, or determining the term grade for students. The TA is not responsible for instructing the entire enrollment of a course or for providing online instruction to a group of students enrolled in a course. Per campus policy APM 410-20 and guidance from November 2025, TAs can be responsible for conducting office hours.</p>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>What are the responsibilities of a Reader?</h3>
-            <p>Readers are employed for the ability to render diverse services as a "course assistant," which normally includes grading student papers and examinations. Readers can also answer questions about grading. A Reader should not be given the responsibilities customarily accorded a Teaching Assistant. Per campus policy APM 420-4 and guidance from November 2025, Readers should not be responsible for holding office hours.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">What are the responsibilities of a Reader?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Readers are employed for the ability to render diverse services as a "course assistant," which normally includes grading student papers and examinations. Readers can also answer questions about grading. A Reader should not be given the responsibilities customarily accorded a Teaching Assistant. Per campus policy APM 420-4 and guidance from November 2025, Readers should not be responsible for holding office hours.</p>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>Is there a class size limit for assigning a Reader?</h3>
-            <p>Campus policy APM 420-21 states, while there is no specific limit to the size of classes for which Readers may be appointed, it is expected that the staff member giving the instruction will perform the reading without appointed Readers in a class of 30 students.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">Is there a class size limit for assigning a Reader?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Campus policy APM 420-21 states, while there is no specific limit to the size of classes for which Readers may be appointed, it is expected that the staff member giving the instruction will perform the reading without appointed Readers in a class of 30 students.</p>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>How are TAs and Readers paid?</h3>
-            <p>TA and Reader positions approved through the CA&amp;ES Dean's Office are funded from Tuition Revenues. Salary scales are posted on the Graduate Studies website. TAs and Readers appointed at a minimum appointment level of 25% are eligible for tuition and fees that are paid centrally through campus allocations. Minimum eligibility and restrictions for academic appointment of graduate students are outlined on the Graduate Studies website.</p>
-            <p>Template appointment letters and descriptions of expectations and duties for all academic student employees are available on the Graduate Studies website. Departments are strongly encouraged to use these templates for hiring TAs and Readers to best ensure compliance with policies.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">How are TAs and Readers paid?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>TA and Reader positions approved through the CA&amp;ES Dean's Office are funded from Tuition Revenues. Salary scales are posted on the Graduate Studies website. TAs and Readers appointed at a minimum appointment level of 25% are eligible for tuition and fees that are paid centrally through campus allocations. Minimum eligibility and restrictions for academic appointment of graduate students are outlined on the Graduate Studies website.</p>
+                <p>Template appointment letters and descriptions of expectations and duties for all academic student employees are available on the Graduate Studies website. Departments are strongly encouraged to use these templates for hiring TAs and Readers to best ensure compliance with policies.</p>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>Where does TACOS get its data?</h3>
-            <p>Information in TACOS is a combination of user-entered data and data extracted from the campus course catalog and historical actual student enrollment from the past two years in Banner. Eligibility criteria are set by a faculty-led committee, which have been updated for the 2026-27 academic year.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">Where does TACOS get its data?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Information in TACOS is a combination of user-entered data and data extracted from the campus course catalog and historical actual student enrollment from the past two years in Banner. Eligibility criteria are set by a faculty-led committee, which have been updated for the 2026-27 academic year.</p>
+            </div>
+        </details>
 
-        <section class="tacos-faq__item">
-            <h3>How should I code TAs and Readers in Aggie Enterprise?</h3>
-            <p>Effective July 1, 2026, TAs and Readers must be paid in chart strings using the 200638 - Teaching Assistants activity code in Aggie Enterprise.</p>
-        </section>
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
+                <span class="tacos-faq__question">How should I code TAs and Readers in Aggie Enterprise?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>Effective July 1, 2026, TAs and Readers must be paid in chart strings using the 200638 - Teaching Assistants activity code in Aggie Enterprise.</p>
+            </div>
+        </details>
     </article>
 </div>

--- a/src/tacos.mvc/Views/Shared/_Layout.cshtml
+++ b/src/tacos.mvc/Views/Shared/_Layout.cshtml
@@ -41,6 +41,9 @@
                 <li>
                     <a class="tacos-site-nav__link @(ViewContext.RouteData.Values["Controller"]?.ToString() == "Courses" ? "tacos-site-nav__link--active" : "")" asp-controller="Courses" asp-action="index">Courses</a>
                 </li>
+                <li>
+                    <a class="tacos-site-nav__link @(ViewContext.RouteData.Values["Controller"]?.ToString() == "Faqs" ? "tacos-site-nav__link--active" : "")" asp-controller="Faqs" asp-action="index">FAQ</a>
+                </li>
                 @if (User.IsInRole("Reviewer"))
                 {
                     <li>

--- a/src/tacos.mvc/wwwroot/js/tacos-ui.js
+++ b/src/tacos.mvc/wwwroot/js/tacos-ui.js
@@ -32,6 +32,43 @@
         }
     }
 
+    function getFaqItems(root) {
+        return Array.from(root.querySelectorAll("[data-tacos-faq-item]"));
+    }
+
+    function syncFaqToggle(root) {
+        const toggleButton = root.querySelector("[data-tacos-faq-toggle]");
+
+        if (!toggleButton) {
+            return;
+        }
+
+        const items = getFaqItems(root);
+        const allExpanded = items.length > 0 && items.every((item) => item.open);
+        const labelAttribute = allExpanded ? "data-collapse-label" : "data-expand-label";
+        const fallbackLabel = allExpanded ? "Collapse all" : "Expand all";
+
+        toggleButton.textContent = toggleButton.getAttribute(labelAttribute) || fallbackLabel;
+        toggleButton.setAttribute("aria-expanded", allExpanded ? "true" : "false");
+    }
+
+    function toggleFaqItems(button) {
+        const root = button.closest("[data-tacos-faq]");
+
+        if (!root) {
+            return;
+        }
+
+        const items = getFaqItems(root);
+        const shouldExpand = items.some((item) => !item.open);
+
+        items.forEach((item) => {
+            item.open = shouldExpand;
+        });
+
+        syncFaqToggle(root);
+    }
+
     document.addEventListener("click", (event) => {
         const target = event.target;
 
@@ -58,10 +95,31 @@
             return;
         }
 
+        const faqToggleButton = target.closest("[data-tacos-faq-toggle]");
+
+        if (faqToggleButton) {
+            toggleFaqItems(faqToggleButton);
+            return;
+        }
+
         const alertDismissButton = target.closest("[data-tacos-dismiss='alert']");
 
         if (alertDismissButton) {
             dismissAlert(alertDismissButton);
         }
     });
+
+    document.addEventListener("toggle", (event) => {
+        const target = event.target;
+
+        if (!(target instanceof HTMLDetailsElement) || !target.matches("[data-tacos-faq-item]")) {
+            return;
+        }
+
+        const root = target.closest("[data-tacos-faq]");
+
+        if (root) {
+            syncFaqToggle(root);
+        }
+    }, true);
 })();


### PR DESCRIPTION
## Summary
- Add a top-level TACOS FAQ page for authenticated users
- Add FAQ navigation beside Courses
- Convert the FAQ content into expandable questions with an Expand all/Collapse all control

## Validation
- dotnet build src/tacos.mvc/tacos.mvc.csproj
- npm run build
- dotnet test Test/Test.csproj --no-restore
- DOM interaction check for collapsed initial state, single expansion, expand all, collapse all, and button-state sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FAQ page accessible from the main navigation menu
  * Implemented expand/collapse functionality for individual FAQ items
  * Added "Expand all/Collapse all" toggle for convenient FAQ browsing with responsive mobile layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/tacos/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->