### PR TITLE
Refine courses search page layout and restore table filter

### DIFF
--- a/Test/Controllers/CoursesControllerTests.cs
+++ b/Test/Controllers/CoursesControllerTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using tacos.core;
+using tacos.core.Data;
+using tacos.mvc.Controllers;
+using tacos.mvc.Models.CourseViewModels;
+using Xunit;
+
+namespace Test.Controllers
+{
+    [Trait("Category", "Controller")]
+    public class CoursesControllerTests
+    {
+        [Fact]
+        public async Task Index_without_query_should_return_empty_search_model()
+        {
+            await using var context = CreateContext();
+            context.Courses.Add(CreateCourse("ANS002"));
+            await context.SaveChangesAsync();
+
+            var model = await IndexModel(context, null);
+
+            model.HasSearched.ShouldBeFalse();
+            model.IsValidSearch.ShouldBeTrue();
+            model.Courses.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public async Task Index_should_return_courses_matching_subject_code()
+        {
+            await using var context = CreateContext();
+            context.Courses.AddRange(
+                CreateCourse("ANS002"),
+                CreateCourse("ANS110"),
+                CreateCourse("ECS032A"));
+            await context.SaveChangesAsync();
+
+            var model = await IndexModel(context, "ANS");
+
+            model.HasSearched.ShouldBeTrue();
+            model.IsValidSearch.ShouldBeTrue();
+            model.Courses.Select(c => c.Number).ShouldBe(new[] { "ANS002", "ANS110" });
+        }
+
+        [Theory]
+        [InlineData("ANS 002")]
+        [InlineData("ANS002")]
+        public async Task Index_should_normalize_course_input_and_return_prefix_matches(string query)
+        {
+            await using var context = CreateContext();
+            context.Courses.AddRange(
+                CreateCourse("ANS002B"),
+                CreateCourse("ANS002"),
+                CreateCourse("ANS002A"),
+                CreateCourse("ANS003"));
+            await context.SaveChangesAsync();
+
+            var model = await IndexModel(context, query);
+
+            model.IsValidSearch.ShouldBeTrue();
+            model.Courses.Select(c => c.Number).ShouldBe(new[] { "ANS002", "ANS002A", "ANS002B" });
+        }
+
+        [Fact]
+        public async Task Index_should_match_spaced_letter_suffix_course_input()
+        {
+            await using var context = CreateContext();
+            context.Courses.AddRange(
+                CreateCourse("ANS002"),
+                CreateCourse("ANS002A"),
+                CreateCourse("ANS002B"));
+            await context.SaveChangesAsync();
+
+            var model = await IndexModel(context, "ANS 002B");
+
+            model.IsValidSearch.ShouldBeTrue();
+            model.NormalizedQuery.ShouldBe("ANS002B");
+            model.Courses.Select(c => c.Number).ShouldBe(new[] { "ANS002B" });
+        }
+
+        [Theory]
+        [InlineData("ANS0")]
+        [InlineData("young adult literature")]
+        public async Task Index_should_reject_non_course_input(string query)
+        {
+            await using var context = CreateContext();
+            context.Courses.Add(CreateCourse("ANS002"));
+            await context.SaveChangesAsync();
+
+            var model = await IndexModel(context, query);
+
+            model.HasSearched.ShouldBeTrue();
+            model.IsValidSearch.ShouldBeFalse();
+            model.ValidationMessage.ShouldBe("Search by a three-letter subject code or course number.");
+            model.Courses.ShouldBeEmpty();
+        }
+
+        private static async Task<CourseIndexViewModel> IndexModel(TacoDbContext context, string query)
+        {
+            var controller = new CoursesController(context);
+            var result = await controller.Index(query);
+            var view = result.ShouldBeOfType<ViewResult>();
+            return view.Model.ShouldBeOfType<CourseIndexViewModel>();
+        }
+
+        private static TacoDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<TacoDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            return new TacoDbContext(options);
+        }
+
+        private static Course CreateCourse(string number)
+        {
+            return new Course
+            {
+                Number = number,
+                Name = $"{number} Course",
+                AverageEnrollment = 10,
+                AverageSectionsPerCourse = 1,
+                TimesOfferedPerYear = 1
+            };
+        }
+    }
+}

--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -597,6 +597,201 @@ hr {
   line-height: 1.2;
 }
 
+.tacos-course-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.tacos-course-search {
+  display: flex;
+  min-height: 23rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 3rem 1.5rem;
+  background-color: #f4f8fc;
+  border-radius: 0.75rem;
+  box-shadow: inset 0 0 6rem rgba(9, 33, 71, 0.08);
+  text-align: center;
+}
+
+.tacos-course-search--compact {
+  min-height: 0;
+  align-items: stretch;
+  gap: 1rem;
+  padding: 1.25rem;
+  text-align: left;
+}
+
+.tacos-course-search__icon {
+  display: inline-flex;
+  width: 4.75rem;
+  height: 4.75rem;
+  align-items: center;
+  justify-content: center;
+  background-color: #14245c;
+  border-radius: 1rem;
+  color: #fff;
+  font-size: 2rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(20, 36, 92, 0.16);
+}
+
+.tacos-course-search--compact .tacos-course-search__icon {
+  display: none;
+}
+
+.tacos-course-search__copy h1 {
+  margin: 0;
+  color: #071126;
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.tacos-course-search__copy p {
+  margin: 0.75rem 0 0;
+  color: #4b5b73;
+  font-size: 1.25rem;
+}
+
+.tacos-course-search--compact .tacos-course-search__copy h1 {
+  font-size: 1.5rem;
+}
+
+.tacos-course-search--compact .tacos-course-search__copy p {
+  font-size: 1rem;
+}
+
+.tacos-course-search__form {
+  display: flex;
+  width: min(100%, 48rem);
+  gap: 0;
+  overflow: hidden;
+  background-color: #fff;
+  border: 1px solid #c8d3df;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.4rem 1rem rgba(9, 33, 71, 0.12);
+}
+
+.tacos-course-search--compact .tacos-course-search__form {
+  width: 100%;
+}
+
+.tacos-course-search__input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  color: #0b3262;
+  font: inherit;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  padding: 1.1rem 1.5rem;
+
+  &:focus {
+    outline: 0;
+  }
+
+  &::placeholder {
+    color: #7f8897;
+  }
+}
+
+.tacos-course-search__button {
+  margin: 0.45rem;
+  border-radius: 0.6rem;
+  padding-right: 1.5rem;
+  padding-left: 1.5rem;
+  font-weight: 700;
+}
+
+.tacos-course-search__chips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem;
+}
+
+.tacos-course-search--compact .tacos-course-search__chips {
+  justify-content: flex-start;
+}
+
+.tacos-course-search__chips a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.25rem 0.9rem;
+  background-color: rgba(255, 255, 255, 0.55);
+  border-radius: 999px;
+  color: #3f4f68;
+  font-weight: 700;
+  text-decoration: none;
+
+  &:hover,
+  &:focus,
+  &:focus-visible {
+    background-color: #fff;
+    color: #14245c;
+    text-decoration: none;
+  }
+}
+
+.tacos-course-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tacos-course-results__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.tacos-course-results__empty {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem;
+  background-color: #fff;
+  border: 1px solid #d3dbe5;
+  color: #4b5b73;
+}
+
+.tacos-course-results__empty i {
+  color: #14245c;
+}
+
+@media (max-width: 640px) {
+  .tacos-course-search {
+    padding: 2rem 1rem;
+  }
+
+  .tacos-course-search__form {
+    flex-direction: column;
+    overflow: visible;
+    background-color: transparent;
+    border: 0;
+    box-shadow: none;
+  }
+
+  .tacos-course-search__input {
+    border: 1px solid #c8d3df;
+    border-radius: 0.75rem;
+    background-color: #fff;
+    font-size: 1rem;
+  }
+
+  .tacos-course-search__button {
+    width: 100%;
+    margin: 0.75rem 0 0;
+    border-radius: 0.6rem;
+  }
+}
+
 .tacos-course-detail-page {
   min-height: calc(100vh - 6rem);
   background-color: #f3f4f6;

--- a/src/tacos.mvc/ClientApp/css/site.scss
+++ b/src/tacos.mvc/ClientApp/css/site.scss
@@ -600,7 +600,7 @@ hr {
 .tacos-course-page {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 2.25rem;
 }
 
 .tacos-course-search {
@@ -611,17 +611,15 @@ hr {
   justify-content: center;
   gap: 1.5rem;
   padding: 3rem 1.5rem;
-  background-color: #f4f8fc;
-  border-radius: 0.75rem;
-  box-shadow: inset 0 0 6rem rgba(9, 33, 71, 0.08);
+  background-color: transparent;
   text-align: center;
 }
 
 .tacos-course-search--compact {
   min-height: 0;
   align-items: stretch;
-  gap: 1rem;
-  padding: 1.25rem;
+  gap: 0.9rem;
+  padding: 0;
   text-align: left;
 }
 
@@ -657,7 +655,7 @@ hr {
 }
 
 .tacos-course-search--compact .tacos-course-search__copy h1 {
-  font-size: 1.5rem;
+  font-size: 2rem;
 }
 
 .tacos-course-search--compact .tacos-course-search__copy p {
@@ -677,6 +675,18 @@ hr {
 
 .tacos-course-search--compact .tacos-course-search__form {
   width: 100%;
+  box-shadow: 0 0.25rem 0.9rem rgba(9, 33, 71, 0.08);
+}
+
+.tacos-course-search--compact .tacos-course-search__input {
+  font-size: 1.1rem;
+  padding-top: 0.85rem;
+  padding-bottom: 0.85rem;
+}
+
+.tacos-course-search--compact .tacos-course-search__button {
+  padding-right: 1.25rem;
+  padding-left: 1.25rem;
 }
 
 .tacos-course-search__input {
@@ -706,41 +716,14 @@ hr {
   font-weight: 700;
 }
 
-.tacos-course-search__chips {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.65rem;
-}
-
-.tacos-course-search--compact .tacos-course-search__chips {
-  justify-content: flex-start;
-}
-
-.tacos-course-search__chips a {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2rem;
-  padding: 0.25rem 0.9rem;
-  background-color: rgba(255, 255, 255, 0.55);
-  border-radius: 999px;
-  color: #3f4f68;
-  font-weight: 700;
-  text-decoration: none;
-
-  &:hover,
-  &:focus,
-  &:focus-visible {
-    background-color: #fff;
-    color: #14245c;
-    text-decoration: none;
-  }
-}
-
 .tacos-course-results {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
+}
+
+.tacos-course-results .tacos-page-heading {
+  font-size: 2rem;
 }
 
 .tacos-course-results__header {

--- a/src/tacos.mvc/Controllers/CoursesController.cs
+++ b/src/tacos.mvc/Controllers/CoursesController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -19,12 +20,46 @@ namespace tacos.mvc.Controllers
             _dbContext = dbContext;
         }
 
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(string q)
         {
-            var courses = await _dbContext.Courses
+            var model = new CourseIndexViewModel
+            {
+                Query = q?.Trim(),
+                HasSearched = !string.IsNullOrWhiteSpace(q)
+            };
+
+            if (!model.HasSearched)
+            {
+                return View(model);
+            }
+
+            model.NormalizedQuery = CourseNumberKey.Normalize(model.Query);
+
+            if (!IsValidCourseSearch(model.NormalizedQuery))
+            {
+                model.IsValidSearch = false;
+                model.ValidationMessage = "Search by a three-letter subject code or course number.";
+                return View(model);
+            }
+
+            model.Courses = await _dbContext.Courses
+                .Where(c => c.Number
+                    .Replace(" ", "")
+                    .Replace("\t", "")
+                    .Replace("\r", "")
+                    .Replace("\n", "")
+                    .ToUpper()
+                    .StartsWith(model.NormalizedQuery))
+                .OrderBy(c => c.Number
+                    .Replace(" ", "")
+                    .Replace("\t", "")
+                    .Replace("\r", "")
+                    .Replace("\n", "")
+                    .ToUpper() == model.NormalizedQuery ? 0 : 1)
+                .ThenBy(c => c.Number)
                 .ToListAsync();
 
-            return View(courses);
+            return View(model);
         }
 
         public async Task<IActionResult> Details(string id)
@@ -76,8 +111,19 @@ namespace tacos.mvc.Controllers
             {
                 return NotFound();
             }
-            
+
             return Json(course);
+        }
+
+        private static bool IsValidCourseSearch(string normalizedQuery)
+        {
+            if (string.IsNullOrWhiteSpace(normalizedQuery))
+            {
+                return false;
+            }
+
+            return Regex.IsMatch(normalizedQuery, "^[A-Z]{3}$")
+                || Regex.IsMatch(normalizedQuery, "^[A-Z]{3}[0-9]{3}[A-Z]?$");
         }
     }
 }

--- a/src/tacos.mvc/Models/CourseViewModels/CourseIndexViewModel.cs
+++ b/src/tacos.mvc/Models/CourseViewModels/CourseIndexViewModel.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using tacos.core.Data;
+
+namespace tacos.mvc.Models.CourseViewModels
+{
+    public class CourseIndexViewModel
+    {
+        public string Query { get; set; }
+
+        public string NormalizedQuery { get; set; }
+
+        public bool HasSearched { get; set; }
+
+        public bool IsValidSearch { get; set; } = true;
+
+        public string ValidationMessage { get; set; }
+
+        public IList<Course> Courses { get; set; } = new List<Course>();
+    }
+}

--- a/src/tacos.mvc/Views/Courses/Index.cshtml
+++ b/src/tacos.mvc/Views/Courses/Index.cshtml
@@ -4,7 +4,6 @@
 @{
     ViewData["Title"] = "Courses";
     var searchClass = Model.HasSearched ? "tacos-course-search tacos-course-search--compact" : "tacos-course-search";
-    var suggestions = new[] { "PMI", "ENL", "MIC", "ANT", "DVM" };
 }
 
 <div class="tacos-page-shell tacos-course-page">
@@ -25,17 +24,12 @@
                 name="q"
                 value="@Model.Query"
                 placeholder="Try PMI, ENL, MIC170, or ANS 002"
+                autofocus
                 autocomplete="off" />
             <button class="tacos-btn tacos-btn--primary tacos-course-search__button" type="submit">
                 Search
             </button>
         </form>
-        <div class="tacos-course-search__chips" aria-label="Common subject searches">
-            @foreach (var suggestion in suggestions)
-            {
-                <a asp-controller="Courses" asp-action="Index" asp-route-q="@suggestion">@suggestion</a>
-            }
-        </div>
     </section>
 
     @if (Model.HasSearched)
@@ -117,8 +111,11 @@
                         "sortable": false
                     }],
                 "order": [[0, "asc"]],
+                "language": {
+                    "search": "Filter:"
+                },
                 "dom":
-                    "<'tacos-datatable-toolbar'<'tacos-datatable-toolbar__length'l>>" +
+                    "<'tacos-datatable-toolbar'<'tacos-datatable-toolbar__length'l><'tacos-datatable-toolbar__actions'f>>" +
                     "<'tacos-datatable-table'tr>" +
                     "<'tacos-datatable-footer'<'tacos-datatable-footer__info'i><'tacos-datatable-footer__pagination'p>>"
             });

--- a/src/tacos.mvc/Views/Courses/Index.cshtml
+++ b/src/tacos.mvc/Views/Courses/Index.cshtml
@@ -1,51 +1,126 @@
-@model IList<tacos.core.Data.Course>
+@using System.Linq
+@model tacos.mvc.Models.CourseViewModels.CourseIndexViewModel
 
-<div class="tacos-page-shell">
-    <div>
-        <table id="coursesTable" class="table tacos-page-table w-full">
-            <thead>
-                <tr>
-                    <th>Number</th>
-                    <th>Name</th>
-                    <th>Average Enrollment</th>
-                    <th>Average Sections</th>
-                    <th>Times Offered / Year</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-            @foreach (var course in Model)
+@{
+    ViewData["Title"] = "Courses";
+    var searchClass = Model.HasSearched ? "tacos-course-search tacos-course-search--compact" : "tacos-course-search";
+    var suggestions = new[] { "PMI", "ENL", "MIC", "ANT", "DVM" };
+}
+
+<div class="tacos-page-shell tacos-course-page">
+    <section class="@searchClass" aria-labelledby="courseSearchHeading">
+        <div class="tacos-course-search__icon" aria-hidden="true">
+            <i class="fas fa-search"></i>
+        </div>
+        <div class="tacos-course-search__copy">
+            <h1 id="courseSearchHeading">Find a course</h1>
+            <p>Search by course number or subject code.</p>
+        </div>
+        <form class="tacos-course-search__form" asp-controller="Courses" asp-action="Index" method="get">
+            <label class="sr-only" for="courseSearchQuery">Course search</label>
+            <input
+                id="courseSearchQuery"
+                class="tacos-course-search__input"
+                type="search"
+                name="q"
+                value="@Model.Query"
+                placeholder="Try PMI, ENL, MIC170, or ANS 002"
+                autocomplete="off" />
+            <button class="tacos-btn tacos-btn--primary tacos-course-search__button" type="submit">
+                Search
+            </button>
+        </form>
+        <div class="tacos-course-search__chips" aria-label="Common subject searches">
+            @foreach (var suggestion in suggestions)
             {
-                <tr>
-                    <td>@course.Number</td>
-                    <td>@course.Name</td>
-                    <td>@course.AverageEnrollment</td>
-                    <td>@course.AverageSectionsPerCourse</td>
-                    <td>@course.TimesOfferedPerYear</td>
-                    <td>
-                        <a class="tacos-btn tacos-btn--primary" asp-controller="Courses" asp-action="Details" asp-route-id="@course.Number">
-                            <i class="fas fa-info tacos-inline-icon-start"></i> Details
-                        </a>
-                    </td>
-                </tr>
+                <a asp-controller="Courses" asp-action="Index" asp-route-q="@suggestion">@suggestion</a>
             }
-            </tbody>
-        </table>
-    </div>
+        </div>
+    </section>
+
+    @if (Model.HasSearched)
+    {
+        <section class="tacos-course-results" aria-live="polite">
+            <div class="tacos-course-results__header">
+                <div>
+                    <h2 class="tacos-page-heading">Search results</h2>
+                    @if (Model.IsValidSearch)
+                    {
+                        <p class="tacos-page-meta">@Model.Courses.Count course@(Model.Courses.Count == 1 ? "" : "s") found for &ldquo;@Model.Query&rdquo;.</p>
+                    }
+                    else
+                    {
+                        <p class="tacos-page-meta">@Model.ValidationMessage</p>
+                    }
+                </div>
+            </div>
+
+            @if (Model.IsValidSearch && Model.Courses.Any())
+            {
+                <div>
+                    <table id="coursesTable" class="table tacos-page-table w-full">
+                        <thead>
+                            <tr>
+                                <th>Number</th>
+                                <th>Name</th>
+                                <th>Average Enrollment</th>
+                                <th>Average Sections</th>
+                                <th>Times Offered / Year</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        @foreach (var course in Model.Courses)
+                        {
+                            <tr>
+                                <td>@course.Number</td>
+                                <td>@course.Name</td>
+                                <td>@course.AverageEnrollment</td>
+                                <td>@course.AverageSectionsPerCourse</td>
+                                <td>@course.TimesOfferedPerYear</td>
+                                <td>
+                                    <a class="tacos-btn tacos-btn--primary" asp-controller="Courses" asp-action="Details" asp-route-id="@course.Number">
+                                        <i class="fas fa-info tacos-inline-icon-start"></i> Details
+                                    </a>
+                                </td>
+                            </tr>
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="tacos-course-results__empty">
+                    <i class="fas fa-search" aria-hidden="true"></i>
+                    <p>No courses found. Try a subject code like ENL or a course number like ANS 002.</p>
+                </div>
+            }
+        </section>
+    }
 </div>
 
 @section scripts
 {
     <script>
         $(function () {
-            $('#coursesTable').DataTable({
+            var $coursesTable = $('#coursesTable');
+
+            if (!$coursesTable.length) {
+                return;
+            }
+
+            $coursesTable.DataTable({
                 "columnDefs": [
                     {
                         "targets": [-1],
                         "sortable": false
                     }],
-                "order": [[1, "desc"]],
-                "dom": window.TacosDataTables.dom.standard
+                "order": [[0, "asc"]],
+                "dom":
+                    "<'tacos-datatable-toolbar'<'tacos-datatable-toolbar__length'l>>" +
+                    "<'tacos-datatable-table'tr>" +
+                    "<'tacos-datatable-footer'<'tacos-datatable-footer__info'i><'tacos-datatable-footer__pagination'p>>"
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- Restored the DataTables filter field on the Courses results table and labeled it `Filter:` for this screen only.
- Tightened the searched-state layout so the search area and results read as one section instead of two mismatched blocks.
- Kept the subject-code pill shortcuts removed and preserved the page-level course search behavior.

## Testing
- `dotnet test Test/Test.csproj` passed.
- Verified the Razor and CSS changes compile cleanly with the existing Courses controller tests still passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added course search functionality allowing users to query courses by subject code or course number.
  * Search intelligently normalizes input formats and displays matching results with validation messaging.

* **Style**
  * Styling applied for course search interface and results display with responsive design.

* **Tests**
  * Added comprehensive test coverage for course search behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/tacos/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->