### PR TITLE
Update CA&ES TA/Reader criteria copy on the home page

### DIFF
--- a/src/tacos.mvc/Views/Home/Index.cshtml
+++ b/src/tacos.mvc/Views/Home/Index.cshtml
@@ -12,11 +12,11 @@
         <div class="tacos-home-panel__body">
             <h4 class="tacos-home-panel__section-title tacos-home-panel__section-title--link">
                 <a href="/CAES-TA-Reader-Criteria-Fall-2026.pdf">
-                    CA&amp;ES TA/Reader Criteria (Fall 2026)
+                    CA&amp;ES TA/Reader Criteria
                 </a>
             </h4>
             <p>
-                Criteria for central TA/Reader funding are updated every 3 years by a committee of CA&amp;ES Faculty.
+                Criteria for central TA/Reader funding are updated regularly by a committee of CA&amp;ES Faculty.
             </p>
             <p>
                 Requests for additional TA or Reader support for courses with unusually special circumstances will be considered using the exception request process.


### PR DESCRIPTION
## Summary
- Remove the “(Fall 2026)” suffix from the CA&ES TA/Reader criteria link text on the home page.
- Update the supporting sentence to say the criteria are updated regularly by a committee of CA&ES Faculty.

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated criteria information to remove time-specific references and clarified update frequency descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/tacos/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->