### PR TITLE
Add cross-listed courses FAQ

### DIFF
--- a/src/tacos.mvc/Views/Faqs/Index.cshtml
+++ b/src/tacos.mvc/Views/Faqs/Index.cshtml
@@ -72,6 +72,15 @@
 
         <details class="tacos-faq__item" data-tacos-faq-item>
             <summary>
+                <span class="tacos-faq__question">How do I enter requests for cross-listed courses?</span>
+            </summary>
+            <div class="tacos-faq__answer">
+                <p>For cross-listed courses, only the department incurring the expenses should enter the request. A request should be submitted for only one of the cross-listed course numbers. Entering a second course request creates a duplicate allocation that the Dean's Office manually removes before finalizing allocations. TACOS has programming logic that identifies cross-listed courses and automatically totals the enrollment for both subject code offerings.</p>
+            </div>
+        </details>
+
+        <details class="tacos-faq__item" data-tacos-faq-item>
+            <summary>
                 <span class="tacos-faq__question">What is the Dean's Office process for allocating funds for TAs and Readers?</span>
             </summary>
             <div class="tacos-faq__answer">


### PR DESCRIPTION
## Summary
- Add FAQ guidance for entering requests for cross-listed courses
- Place the new question after the TACOS course type selection FAQ

## Testing
- Not run; static FAQ content change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ entry explaining the process for submitting requests for cross-listed courses, including guidance on single request submission and enrollment totaling across offerings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->