### PR TITLE
Recalculate request details summary on page load

### DIFF
--- a/Test/Controllers/RequestsControllerTests.cs
+++ b/Test/Controllers/RequestsControllerTests.cs
@@ -584,6 +584,82 @@ namespace Test.Controllers
         }
 
         [Fact]
+        public async Task Details_should_recalculate_summary_without_persisting_or_changing_history()
+        {
+            await using var context = CreateContext();
+            var user = CreateUser();
+            var department = CreateDepartment(1, "ECS");
+            var course = CreateCourse("ECS 261", averageEnrollment: 250);
+            var request = new Request
+            {
+                Department = department,
+                DepartmentId = department.Id,
+                Course = course,
+                CourseNumber = course.Number,
+                CourseType = "MAN",
+                Exception = true,
+                ExceptionTaTotal = 1.5,
+                ExceptionReaderTotal = 0.25,
+                ExceptionAnnualCount = 3,
+                ExceptionAnnualizedTaTotal = 99,
+                ExceptionAnnualizedReaderTotal = 88,
+                CalculatedTaTotal = 77,
+                CalculatedReaderTotal = 66,
+                AnnualizedTaTotal = 55,
+                AnnualizedReaderTotal = 44,
+                History = new List<RequestHistory>
+                {
+                    new()
+                    {
+                        Department = department,
+                        DepartmentId = department.Id,
+                        CourseNumber = course.Number,
+                        CourseType = "MAN",
+                        Exception = true,
+                        ExceptionTaTotal = 2,
+                        ExceptionReaderTotal = 3,
+                        CalculatedTaTotal = 4,
+                        CalculatedReaderTotal = 5,
+                        AnnualizedTaTotal = 6,
+                        AnnualizedReaderTotal = 7,
+                        UpdatedOn = DateTime.UtcNow
+                    }
+                }
+            };
+
+            await SeedMembership(context, user, department);
+            context.Courses.Add(course);
+            context.Requests.Add(request);
+            await context.SaveChangesAsync();
+            context.ChangeTracker.Clear();
+
+            var controller = CreateController(context, user);
+
+            var result = await controller.Details(request.Id);
+
+            var view = result.ShouldBeOfType<ViewResult>();
+            var model = view.Model.ShouldBeOfType<Request>();
+            model.CalculatedTaTotal.ShouldBe(0.25);
+            model.CalculatedReaderTotal.ShouldBe(0.5);
+            model.AnnualizedTaTotal.ShouldBe(0.08333333333333333, 0.000001);
+            model.AnnualizedReaderTotal.ShouldBe(0.16666666666666666, 0.000001);
+            model.ExceptionAnnualizedTaTotal.ShouldBe(1.5);
+            model.ExceptionAnnualizedReaderTotal.ShouldBe(0.25);
+
+            var history = model.History.Single();
+            history.CalculatedTaTotal.ShouldBe(4);
+            history.CalculatedReaderTotal.ShouldBe(5);
+            history.AnnualizedTaTotal.ShouldBe(6);
+            history.AnnualizedReaderTotal.ShouldBe(7);
+
+            var storedRequest = await context.Requests.AsNoTracking().SingleAsync(r => r.Id == request.Id);
+            storedRequest.CalculatedTaTotal.ShouldBe(77);
+            storedRequest.CalculatedReaderTotal.ShouldBe(66);
+            storedRequest.AnnualizedTaTotal.ShouldBe(55);
+            storedRequest.AnnualizedReaderTotal.ShouldBe(44);
+        }
+
+        [Fact]
         public async Task Recalculate_should_return_server_calculated_totals_for_existing_courses()
         {
             await using var context = CreateContext();

--- a/src/tacos.mvc/Controllers/RequestsController.cs
+++ b/src/tacos.mvc/Controllers/RequestsController.cs
@@ -85,7 +85,21 @@ namespace tacos.mvc.Controllers
                 .Include(r => r.Course)
                 .Include(r => r.History)
                 .Where(r => departmentIds.Contains(r.DepartmentId))
+                .AsNoTracking()
                 .SingleAsync(x => x.Id == id);
+
+            ApplySupportTotals(
+                request,
+                _requestCalculationService.Calculate(
+                    request.Course,
+                    new RequestCalculationInput(
+                        request.CourseType,
+                        request.ExceptionTaTotal,
+                        request.ExceptionReaderTotal,
+                        request.ExceptionAnnualCount
+                    )
+                )
+            );
 
             return View(request);
         }


### PR DESCRIPTION
## Summary
- Recalculate the `Request Details` allocation summary from the current `RequestCalculationService` when opening the details page.
- Leave `RequestHistory` untouched so historical snapshots and FTE values remain as originally stored.
- Add a controller test covering the recalculated summary path and verifying persisted request values and history entries are not modified.

## Testing
- Added a new `RequestsController` unit test for details-page recalculation behavior.
- Existing controller test coverage still passes for request save, submit, recalculate, and history behavior.
- Not run (not requested)